### PR TITLE
Fixed UpdateExpression.encode value cache

### DIFF
--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -314,15 +314,16 @@ class TableDescription:
 class Encoder:
     prefix: str = attr.ib()
     data: List[Any] = attr.ib(default=attr.Factory(list))
-    cache: Dict[Any, Any] = attr.ib(default=attr.Factory(dict))
+    cache: Dict[Tuple[Any, Any], Any] = attr.ib(default=attr.Factory(dict))
 
     def finalize(self) -> Dict[str, str]:
         return {f"{self.prefix}{index}": value for index, value in enumerate(self.data)}
 
     def encode(self, name: Any) -> str:
         key = maybe_immutable(name)
+        cache_key = (type(key), key)
         try:
-            return self.cache[key]
+            return self.cache[cache_key]
 
         except KeyError:
             can_cache = True
@@ -331,7 +332,7 @@ class Encoder:
         encoded = f"{self.prefix}{len(self.data)}"
         self.data.append(name)
         if can_cache:
-            self.cache[key] = encoded
+            self.cache[cache_key] = encoded
         return encoded
 
     def encode_path(self, path: Path) -> str:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -21,7 +21,15 @@ def test_project(pe, expression, names):
 
 @pytest.mark.parametrize(
     "exp,ue,ean,eav",
-    [(F("d").set({"k": "v"}), "SET #N0 = :V0", {"#N0": "d"}, {":V0": {"k": "v"}})],
+    [
+        (F("d").set({"k": "v"}), "SET #N0 = :V0", {"#N0": "d"}, {":V0": {"k": "v"}}),
+        (
+            F("iz").set(0) & F("bf").set(False) & F("io").set(1) & F("bt").set(True),
+            "SET #N0 = :V0, #N1 = :V1, #N2 = :V2, #N3 = :V3",
+            {"#N0": "iz", "#N1": "bf", "#N2": "io", "#N3": "bt"},
+            {":V0": 0, ":V1": False, ":V2": 1, ":V3": True},
+        ),
+    ],
 )
 def test_update_expression(exp, ue, ean, eav):
     assert exp.encode() == (ue, ean, eav)


### PR DESCRIPTION
The value cache for ExpressionAttributeValues in UpdateExpression.encode had a bug where 0 and False as well as 1 and True would get mixed up.

Fixes #6 