### PR TITLE
added faster dynamodb item deserializer

### DIFF
--- a/benchmarks/deserialize/README.md
+++ b/benchmarks/deserialize/README.md
@@ -1,0 +1,5 @@
+Run:
+
+* `poetry run  python bench_boto3.py -o boto3.json --rigorous`
+* `poetry run python bench_aiodynamo.py -o aiodynamo.json --rigorous`
+* `poetry run python -m pyperf compare boto3.json aiodynamo.json`

--- a/benchmarks/deserialize/bench_aiodynamo.py
+++ b/benchmarks/deserialize/bench_aiodynamo.py
@@ -1,0 +1,14 @@
+from pyperf import Runner
+
+from aiodynamo.utils import deserialize
+from utils import generate_data
+
+
+data = generate_data()
+
+
+def deserialize_aiodynamo():
+    result = [{k: deserialize(v, float) for k, v in item.items()} for item in data]
+
+
+Runner().bench_func("deserialize", deserialize_aiodynamo)

--- a/benchmarks/deserialize/bench_boto3.py
+++ b/benchmarks/deserialize/bench_boto3.py
@@ -1,0 +1,16 @@
+from boto3.dynamodb.types import TypeDeserializer
+from pyperf import Runner
+
+from utils import generate_data
+
+
+data = generate_data()
+
+
+def deserialize_aiodynamo():
+    result = [
+        {k: TypeDeserializer().deserialize(v) for k, v in item.items()} for item in data
+    ]
+
+
+Runner().bench_func("deserialize", deserialize_aiodynamo)

--- a/benchmarks/deserialize/utils.py
+++ b/benchmarks/deserialize/utils.py
@@ -1,0 +1,20 @@
+def generate_item(nest):
+    item = {
+        "hash": {"S": "string",},
+        "range": {"B": b"bytes",},
+        "null": {"NULL": True},
+        "true": {"BOOL": True},
+        "false": {"BOOL": False},
+        "int": {"N": "42"},
+        "float": {"N": "4.2"},
+        "numeric_set": {"NS": ["42", "4.2"]},
+        "string_set": {"SS": ["hello", "world"]},
+        "binary_set": {"BS": [b"hello", b"world"]},
+    }
+    if nest:
+        item["list"] = {"L": [{"M": generate_item(False)}]}
+    return item
+
+
+def generate_data(num_items=30_000):
+    return [generate_item(True) for _ in range(num_items)]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,8 @@ Changelog
 Release Date: Unreleased
 
 * Added TTL support
-* Fixed a typo in `delete_item`
+* Fixed a typo in ``delete_item``
+* Improved item deserialization performance
 
 19.9
 ----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,15 @@ aiohttp = ">=3.5.4"
 pytest = "^3.0"
 pytest-asyncio = "^0.10.0"
 pytest-cov = "^2.6"
-black = {version = "^18.3-alpha.0",allow-prereleases = true}
+black = {version = "^19.10b0",allow-prereleases = true}
 sphinx = "^1.8"
+pyperf = "^1.7.0"
+
+[tool.isort]
+line_length = "88"
+multi_line_output = "3"
+combine_as_imports = "1"
+include_trailing_comma = "True"
 
 [tool.isort]
 line_length = "88"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,6 @@ multi_line_output = "3"
 combine_as_imports = "1"
 include_trailing_comma = "True"
 
-[tool.isort]
-line_length = "88"
-multi_line_output = "3"
-combine_as_imports = "1"
-include_trailing_comma = "True"
-
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator, Dict, List, TypeVar, Union
 
 import attr
 from boto3.dynamodb.conditions import ConditionBase, ConditionExpressionBuilder
+from boto3.dynamodb.types import DYNAMODB_CONTEXT
 from botocore.exceptions import ClientError
 
 from .errors import EmptyItem, ItemNotFound, TableNotFound
@@ -197,6 +198,8 @@ class Table:
 class Client:
     # core is an aiobotocore DynamoDB client, use aiobotocore.get_session().create_client("dynamodb") to create one.
     core = attr.ib()
+    # pass `float` if you want numeric types returned as floats
+    numeric_type = attr.ib(default=DYNAMODB_CONTEXT.create_decimal)
 
     def table(self, name: TableName) -> Table:
         return Table(self, name)
@@ -339,7 +342,7 @@ class Client:
             )
         )
         if "Attributes" in resp:
-            return dy2py(resp["Attributes"])
+            return dy2py(resp["Attributes"], self.numeric_type)
 
         else:
             return None
@@ -368,7 +371,7 @@ class Client:
             )
         )
         if "Item" in resp:
-            return dy2py(resp["Item"])
+            return dy2py(resp["Item"], self.numeric_type)
 
         else:
             raise ItemNotFound(key)
@@ -406,7 +409,7 @@ class Client:
             )
         )
         if "Attributes" in resp:
-            return dy2py(resp["Attributes"])
+            return dy2py(resp["Attributes"], self.numeric_type)
 
         else:
             return None
@@ -474,7 +477,7 @@ class Client:
             limit,
             "Limit",
         ):
-            yield dy2py(raw)
+            yield dy2py(raw, self.numeric_type)
 
     async def scan(
         self,
@@ -519,7 +522,7 @@ class Client:
             limit,
             "Limit",
         ):
-            yield dy2py(raw)
+            yield dy2py(raw, self.numeric_type)
 
     async def count(
         self,
@@ -611,7 +614,7 @@ class Client:
             )
         )
         if "Attributes" in resp:
-            return dy2py(resp["Attributes"])
+            return dy2py(resp["Attributes"], self.numeric_type)
 
         else:
             return None

--- a/src/aiodynamo/types.py
+++ b/src/aiodynamo/types.py
@@ -1,6 +1,6 @@
-from typing import TypeVar, Dict, Any, List, Union, Callable
+from typing import Any, Callable, Dict, List, TypeVar, Union
 
-from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from boto3.dynamodb.types import TypeSerializer
 
 Item = TypeVar("Item", bound=Dict[str, Any])
 DynamoItem = TypeVar("DynamoItem", bound=Dict[str, Dict[str, Any]])
@@ -12,10 +12,9 @@ NOTHING = object()
 EMPTY = object()
 
 
-class BinaryTypeDeserializer(TypeDeserializer):
-    def _deserialize_b(self, value):
-        return value
-
-
 Serializer = TypeSerializer()
-Deserializer = BinaryTypeDeserializer()
+
+
+SIMPLE_TYPES = frozenset({"BOOL", "S", "B"})
+SIMPLE_SET_TYPES = frozenset({"SS", "BS"})
+NULL_TYPE = "NULL"


### PR DESCRIPTION
local results from the benchmarks:

```
❯ poetry run python -mpyperf stats aiodynamo.json
Total duration: 2 min 14.1 sec
Start date: 2020-02-18 15:29:37
End date: 2020-02-18 15:32:47
Raw value minimum: 709 ms
Raw value maximum: 942 ms

Number of calibration run: 1
Number of run with values: 40
Total number of run: 41

Number of warmup per run: 1
Number of value per run: 3
Loop iterations per value: 1
Total number of values: 120

Minimum:         709 ms
Median +- MAD:   871 ms +- 35 ms
Mean +- std dev: 839 ms +- 76 ms
Maximum:         942 ms

  0th percentile: 709 ms (-16% of the mean) -- minimum
  5th percentile: 717 ms (-15% of the mean)
 25th percentile: 747 ms (-11% of the mean) -- Q1
 50th percentile: 871 ms (+4% of the mean) -- median
 75th percentile: 899 ms (+7% of the mean) -- Q3
 95th percentile: 934 ms (+11% of the mean)
100th percentile: 942 ms (+12% of the mean) -- maximum

Number of outlier (out of 521 ms..1125 ms): 0
❯ poetry run python -mpyperf stats boto3.json
Total duration: 4 min 29.3 sec
Start date: 2020-02-18 14:59:40
End date: 2020-02-18 15:05:06
Raw value minimum: 1.51 sec
Raw value maximum: 2.03 sec

Number of calibration run: 1
Number of run with values: 40
Total number of run: 41

Number of warmup per run: 1
Number of value per run: 3
Loop iterations per value: 1
Total number of values: 120

Minimum:         1.51 sec
Median +- MAD:   1.61 sec +- 0.06 sec
Mean +- std dev: 1.65 sec +- 0.11 sec
Maximum:         2.03 sec

  0th percentile: 1.51 sec (-9% of the mean) -- minimum
  5th percentile: 1.53 sec (-7% of the mean)
 25th percentile: 1.57 sec (-5% of the mean) -- Q1
 50th percentile: 1.61 sec (-3% of the mean) -- median
 75th percentile: 1.75 sec (+6% of the mean) -- Q3
 95th percentile: 1.82 sec (+10% of the mean)
100th percentile: 2.03 sec (+23% of the mean) -- maximum

Number of outlier (out of 1.30 sec..2.01 sec): 1
```