### PR TITLE
Fixed KeyError on describe_time_to_live response

### DIFF
--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -258,7 +258,7 @@ class Client:
         response = await self.core.describe_time_to_live(TableName=table)
         return TimeToLiveDescription(
             table=table,
-            attribute=response["TimeToLiveDescription"]["AttributeName"],
+            attribute=response["TimeToLiveDescription"].get("AttributeName"),
             status=TimeToLiveStatus(
                 response["TimeToLiveDescription"]["TimeToLiveStatus"]
             ),


### PR DESCRIPTION
describe_time_to_live response does not return ["TimeToLiveDescription"] ["AttributeName"] when the status is disabled.