### PR TITLE
Scan with projection only

### DIFF
--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -561,6 +561,7 @@ class Client:
             payload["FilterExpression"] = filter_expression.encode(params)
         if projection or filter_expression:
             payload["ExpressionAttributeNames"] = params.get_expression_names()
+        if filter_expression:
             payload["ExpressionAttributeValues"] = params.get_expression_values()
 
         async for result in self._depaginate("Scan", payload, limit):

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -276,3 +276,12 @@ async def test_update_item_with_broken_update_expression(
         await client.update_item(
             table, {"h": "h", "r": "r"}, F("f").set(2) & F("f").set(3)
         )
+
+
+async def test_scan_with_projection_only(client: Client, table: TableName):
+    item1 = {"h": "h", "r": "1", "d": "x"}
+    item2 = {"h": "h", "r": "2", "d": "y"}
+    await client.put_item(table, item1)
+    await client.put_item(table, item2)
+    items = [item async for item in client.scan(table, projection=F("d"))]
+    assert items == [{"d": "x"}, {"d": "y"}]


### PR DESCRIPTION
Bug in `scan` where providing a ProjectionExpression but no FilterExpression would lead to an invalid payload.