### PR TITLE
make RequestFailed simpler, add retry

### DIFF
--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -664,6 +664,8 @@ class Client:
                 except RequestFailed as exc:
                     logger.debug("request failed")
                     failed = exc
+                except ServiceUnavailable:
+                    logger.debug("service unavailable")
         except Throttled:
             if failed is not None:
                 raise failed

--- a/src/aiodynamo/errors.py
+++ b/src/aiodynamo/errors.py
@@ -136,6 +136,10 @@ class ExpiredToken(AIODynamoError):
     pass
 
 
+class ServiceUnavailable(AIODynamoError):
+    pass
+
+
 ERRORS = {
     "ResourceNotFoundException": TableNotFound,
     "UnknownOperationException": UnknownOperation,
@@ -167,6 +171,8 @@ ERRORS = {
 def exception_from_response(status: int, body: bytes) -> Exception:
     if status == 500:
         return InternalDynamoError()
+    elif status == 503:
+        raise ServiceUnavailable()
     try:
         data = json.loads(body)
         return ERRORS[data["__type"].split("#", 1)[1]](data)

--- a/src/aiodynamo/http/aiohttp.py
+++ b/src/aiodynamo/http/aiohttp.py
@@ -33,7 +33,7 @@ class AIOHTTP(HTTP):
             method="GET", url=url, headers=headers, timeout=timeout
         ) as response:
             if response.status >= 400:
-                raise RequestFailed(response.status)
+                raise RequestFailed()
             return await response.read()
 
     @wrap_errors

--- a/src/aiodynamo/http/aiohttp.py
+++ b/src/aiodynamo/http/aiohttp.py
@@ -3,7 +3,7 @@ from functools import wraps
 from typing import Any, Dict, Optional
 
 from aiodynamo.types import Timeout
-from aiohttp import ClientError, ClientResponseError, ClientSession
+from aiohttp import ClientError, ClientSession
 from yarl import URL
 
 from ..errors import exception_from_response
@@ -15,14 +15,6 @@ def wrap_errors(coro):
     async def wrapper(*args, **kwargs):
         try:
             return await coro(*args, **kwargs)
-        except ClientResponseError as exc:
-            raise RequestFailed(
-                exc.request_info.url,
-                exc.status,
-                exc.message,
-                exc.request_info.headers,
-                None,
-            )
         except ClientError:
             raise RequestFailed()
 
@@ -41,9 +33,7 @@ class AIOHTTP(HTTP):
             method="GET", url=url, headers=headers, timeout=timeout
         ) as response:
             if response.status >= 400:
-                raise RequestFailed(
-                    url, response.status, await response.read(), headers, None
-                )
+                raise RequestFailed(response.status)
             return await response.read()
 
     @wrap_errors

--- a/src/aiodynamo/http/base.py
+++ b/src/aiodynamo/http/base.py
@@ -1,5 +1,4 @@
 import abc
-from dataclasses import dataclass
 from typing import *
 
 from aiodynamo.types import Timeout
@@ -8,13 +7,8 @@ from yarl import URL
 Headers = Mapping[str, str]
 
 
-@dataclass
 class RequestFailed(Exception):
-    url: Optional[URL] = None
-    status: Optional[int] = None
-    response: Optional[bytes] = None
-    headers: Optional[Headers] = None
-    body: Optional[bytes] = None
+    pass
 
 
 class HTTP(metaclass=abc.ABCMeta):

--- a/src/aiodynamo/http/httpx.py
+++ b/src/aiodynamo/http/httpx.py
@@ -16,14 +16,8 @@ def wrap_errors(coro):
     async def wrapper(*args, **kwargs):
         try:
             return await coro(*args, **kwargs)
-        except HTTPError as exc:
-            raise RequestFailed(
-                exc.request and exc.request.url,
-                exc.response and exc.response.status_code,
-                exc.response and await exc.response.aread(),
-                exc.request and exc.request.headers,
-                exc.request and await exc.request.aread(),
-            )
+        except HTTPError:
+            raise RequestFailed()
 
     return wrapper
 
@@ -38,9 +32,7 @@ class HTTPX(HTTP):
     ) -> bytes:
         response = await self.client.get(str(url), headers=headers, timeout=timeout)
         if response.status_code >= 400:
-            raise RequestFailed(
-                url, response.status_code, await response.aread(), headers
-            )
+            raise RequestFailed()
         return await response.aread()
 
     @wrap_errors


### PR DESCRIPTION
Remove all the extra info from `RequestFailed`, the caller can still get it from the chained exception. Add super simple retry logic to `send_request` retrying all `RequestFailed` errors.