### PR TITLE
Fix put_item and delete_item conditions without values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+20.4.1
+------
+
+Release Date: Unreleased
+
+* Fixed ``put_item`` with a ``condition`` which does not carry any values.
+
 20.4
 ----
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Release Date: Unreleased
 
-* Fixed ``put_item`` with a ``condition`` which does not carry any values.
+* Fixed ``put_item`` and ``delete_item`` with a ``condition`` which does not carry any values.
 
 20.4
 ----

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -478,7 +478,9 @@ class Client:
             params = Parameters()
             payload["ConditionExpression"] = condition.encode(params)
             payload["ExpressionAttributeNames"] = params.get_expression_names()
-            payload["ExpressionAttributeValues"] = params.get_expression_values()
+            values = params.get_expression_values()
+            if values:
+                payload["ExpressionAttributeValues"] = values
 
         resp = await self.send_request(action="PutItem", payload=payload)
 

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -408,8 +408,7 @@ class Client:
         if condition:
             params = Parameters()
             payload["ConditionExpression"] = condition.encode(params)
-            payload["ExpressionAttributeNames"] = params.get_expression_names()
-            payload["ExpressionAttributeValues"] = params.get_expression_values()
+            payload.update(params.to_request_payload())
 
         resp = await self.send_request(action="DeleteItem", payload=payload)
         if "Attributes" in resp:
@@ -449,7 +448,7 @@ class Client:
         if projection:
             params = Parameters()
             payload["ProjectionExpression"] = projection.encode(params)
-            payload["ExpressionAttributeNames"] = params.get_expression_names()
+            payload.update(params.to_request_payload())
 
         resp = await self.send_request(action="GetItem", payload=payload)
         if "Item" in resp:
@@ -477,10 +476,7 @@ class Client:
         if condition:
             params = Parameters()
             payload["ConditionExpression"] = condition.encode(params)
-            payload["ExpressionAttributeNames"] = params.get_expression_names()
-            values = params.get_expression_values()
-            if values:
-                payload["ExpressionAttributeValues"] = values
+            payload.update(params.to_request_payload())
 
         resp = await self.send_request(action="PutItem", payload=payload)
 
@@ -529,8 +525,7 @@ class Client:
         if select:
             payload["Select"] = select.value
 
-        payload["ExpressionAttributeNames"] = params.get_expression_names()
-        payload["ExpressionAttributeValues"] = params.get_expression_values()
+        payload.update(params.to_request_payload())
 
         async for result in self._depaginate("Query", payload, limit):
             for item in result["Items"]:
@@ -561,10 +556,8 @@ class Client:
             payload["ProjectionExpression"] = projection.encode(params)
         if filter_expression:
             payload["FilterExpression"] = filter_expression.encode(params)
-        if projection or filter_expression:
-            payload["ExpressionAttributeNames"] = params.get_expression_names()
-        if filter_expression:
-            payload["ExpressionAttributeValues"] = params.get_expression_values()
+
+        payload.update(params.to_request_payload())
 
         async for result in self._depaginate("Scan", payload, limit):
             for item in result["Items"]:
@@ -593,8 +586,9 @@ class Client:
             payload["FilterExpression"] = filter_expression.encode(params)
         if index:
             payload["IndexName"] = index
-        payload["ExpressionAttributeNames"] = params.get_expression_names()
-        payload["ExpressionAttributeValues"] = params.get_expression_values()
+
+        payload.update(params.to_request_payload())
+
         count_sum = 0
         async for result in self._depaginate("Query", payload):
             count_sum += result["Count"]
@@ -624,10 +618,7 @@ class Client:
         if condition:
             payload["ConditionExpression"] = condition.encode(params)
 
-        payload["ExpressionAttributeNames"] = params.get_expression_names()
-        values = params.get_expression_values()
-        if values:
-            payload["ExpressionAttributeValues"] = values
+        payload.update(params.to_request_payload())
 
         resp = await self.send_request(action="UpdateItem", payload=payload)
 

--- a/src/aiodynamo/expressions.py
+++ b/src/aiodynamo/expressions.py
@@ -327,11 +327,15 @@ class Parameters:
                 bits.append(f".{self.encode_name(part)}")
         return "".join(bits)
 
-    def get_expression_names(self) -> Dict[str, str]:
-        return self.names
-
-    def get_expression_values(self) -> Dict[str, Dict[str, Any]]:
-        return {key: value for key, value in self.values.items()}
+    def to_request_payload(self) -> Dict[str, Union[str, Dict[str, Any]]]:
+        payload = {}
+        if self.names:
+            payload["ExpressionAttributeNames"] = self.names
+        if self.values:
+            payload["ExpressionAttributeValues"] = {
+                key: value for key, value in self.values.items()
+            }
+        return payload
 
     def _encode(
         self,

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -285,3 +285,13 @@ async def test_scan_with_projection_only(client: Client, table: TableName):
     await client.put_item(table, item2)
     items = [item async for item in client.scan(table, projection=F("d"))]
     assert items == [{"d": "x"}, {"d": "y"}]
+
+
+async def test_put_item_with_condition_with_no_values(client: Client, table: TableName):
+    await client.put_item(
+        table, {"h": "h", "r": "1"}, condition=F("h").does_not_exist()
+    )
+    with pytest.raises(errors.ConditionalCheckFailed):
+        await client.put_item(
+            table, {"h": "h", "r": "1"}, condition=F("h").does_not_exist()
+        )

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -295,3 +295,12 @@ async def test_put_item_with_condition_with_no_values(client: Client, table: Tab
         await client.put_item(
             table, {"h": "h", "r": "1"}, condition=F("h").does_not_exist()
         )
+
+
+async def test_delete_item_with_conditions(client: Client, table: TableName):
+    await client.put_item(table, {"h": "h", "r": "1", "d": "x"})
+    with pytest.raises(errors.ConditionalCheckFailed):
+        await client.delete_item(
+            table, {"h": "h", "r": "1"}, condition=F("d").does_not_exist()
+        )
+    assert await client.get_item(table, {"h": "h", "r": "1"})

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -17,8 +17,9 @@ from aiodynamo.expressions import F, Parameters
 def test_project(pe, expression, names):
     params = Parameters()
     assert pe.encode(params) == expression
-    assert params.get_expression_names() == names
-    assert params.get_expression_values() == {}
+    payload = params.to_request_payload()
+    assert payload["ExpressionAttributeNames"] == names
+    assert "ExpressionAttributeValues" not in payload
 
 
 @pytest.mark.parametrize(
@@ -46,5 +47,6 @@ def test_project(pe, expression, names):
 def test_update_expression(exp, ue, ean, eav):
     params = Parameters()
     assert exp.encode(params) == ue
-    assert params.get_expression_names() == ean
-    assert params.get_expression_values() == eav
+    payload = params.to_request_payload()
+    assert payload["ExpressionAttributeNames"] == ean
+    assert payload["ExpressionAttributeValues"] == eav


### PR DESCRIPTION
fixes `put_item` and `delete_item` with conditions that do not carry values.

refactors how parameters are injected into the payload to prevent these kind of bugs in the future.