### PR TITLE
Fix comparison condition expressions

### DIFF
--- a/src/aiodynamo/expressions.py
+++ b/src/aiodynamo/expressions.py
@@ -522,7 +522,11 @@ class SizeCondition(Condition):
     value: Any
 
     def encode(self, params: Parameters) -> str:
-        return f"size({params.encode_path(self.field.path)}) {self.operator} {params.encode_value(self.value)}"
+        if isinstance(self.value, F):
+            value = params.encode_path(self.value.path)
+        else:
+            value = params.encode_value(self.value)
+        return f"size({params.encode_path(self.field.path)}) {self.operator} {value}"
 
 
 class SetAction(metaclass=abc.ABCMeta):

--- a/src/aiodynamo/expressions.py
+++ b/src/aiodynamo/expressions.py
@@ -489,7 +489,11 @@ class Comparison(Condition):
     other: Any
 
     def encode(self, params: Parameters) -> str:
-        return f"{params.encode_path(self.field.path)} {self.operator} {params.encode_value(self.other)}"
+        if isinstance(self.other, F):
+            other = params.encode_path(self.other.path)
+        else:
+            other = params.encode_value(self.other)
+        return f"{params.encode_path(self.field.path)} {self.operator} {other}"
 
 
 @dataclass(frozen=True)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -331,7 +331,7 @@ async def test_size_condition_expression(client: Client, table: TableName):
         table,
         key,
         update_expression=F("v").set("final"),
-        condition=F("s").size().gt(6),
+        condition=F("s").size().lt(6),
     )
     item = await client.get_item(table, key)
     assert item["v"] == "final"


### PR DESCRIPTION
Fixes #41

The right hand side of comparisons (including `size(...)` comparisons) can be other fields (which isn't really mentioned in their [docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html)).