### PR TITLE
Improved the way the client handles no key being returned from credentials

### DIFF
--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -634,6 +634,10 @@ class Client:
         try:
             async for _ in self.throttle_config.attempts():
                 key = await self.credentials.get_key(self.http)
+                if key is None:
+                    logger.debug("no credentials found")
+                    failed = NoCredentialsFound()
+                    continue
                 request = signed_dynamo_request(
                     key=key,
                     payload=payload,

--- a/src/aiodynamo/errors.py
+++ b/src/aiodynamo/errors.py
@@ -5,6 +5,10 @@ class AIODynamoError(Exception):
     pass
 
 
+class NoCredentialsFound(Exception):
+    pass
+
+
 class EmptyItem(AIODynamoError):
     pass
 

--- a/src/aiodynamo/errors.py
+++ b/src/aiodynamo/errors.py
@@ -5,7 +5,7 @@ class AIODynamoError(Exception):
     pass
 
 
-class NoCredentialsFound(Exception):
+class NoCredentialsFound(AIODynamoError):
     pass
 
 


### PR DESCRIPTION
Currently, when no credentials can be found, the client fails with a strange `AttributeError`. This change will make the client retry on credentials resolving failure and raise an appropriate error if no credentials could ever be fetched.