### PR TITLE
remove empty string handling

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -26,14 +26,6 @@ Autopagination
 DynamoDB APIs that return a paginated result, such as ``scan``, ``query`` or ``count`` are automatically de-paginated in
 aiodynamo and return asynchronous iterators over the whole result set instead.
 
-Empty String Safe
-~~~~~~~~~~~~~~~~~
-
-DynamoDB APIs will return an error if an item contains an empty string as a value anywhere. aiodynamo removes these
-values automatically wherever it can. This means that trying to set a field to an empty string in
-:py:meth:`aiodynamo.client.Client.update_item` will instead remove that field. In :py:meth:`aiodynamo.client.Client.put_item`
-that field is simply omitted.
-
 Numeric type handling
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/aiodynamo/expressions.py
+++ b/src/aiodynamo/expressions.py
@@ -304,18 +304,16 @@ class Parameters:
             "#n", name, self.names, self.names_gen, self.names_cache, name
         )
 
-    def encode_value(self, value: Any) -> Optional[str]:
-        value = low_level_serialize(value)
-        if value:
-            return self._encode(
-                ":v",
-                {value[0]: value[1]},
-                self.values,
-                self.values_gen,
-                self.values_cache,
-                value,
-            )
-        return None
+    def encode_value(self, value: Any) -> str:
+        tag, value = low_level_serialize(value)
+        return self._encode(
+            ":v",
+            {tag: value},
+            self.values,
+            self.values_gen,
+            self.values_cache,
+            (tag, value),
+        )
 
     def encode_path(self, path: KeyPath) -> str:
         bits = [self.encode_name(path[0])]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,8 +17,13 @@ def table_name_prefix() -> str:
 
 
 @pytest.fixture
-def endpoint() -> Optional[URL]:
-    if os.environ.get("TEST_ON_AWS", "false") == "true":
+def real_dynamo() -> bool:
+    return os.environ.get("TEST_ON_AWS", "false") == "true"
+
+
+@pytest.fixture
+def endpoint(real_dynamo) -> Optional[URL]:
+    if real_dynamo:
         return None
     if "DYNAMODB_URL" not in os.environ:
         raise pytest.skip("DYNAMODB_URL not defined in environment")

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -10,6 +10,7 @@ from aiodynamo.errors import (
     NoCredentialsFound,
     TableNotFound,
     UnknownOperation,
+    ValidationException,
 )
 from aiodynamo.expressions import F, HashKey, RangeKey
 from aiodynamo.http.base import HTTP
@@ -204,7 +205,9 @@ async def test_exists(client: Client, table_factory):
         await client.describe_table(name)
 
 
-async def test_empty_string(client: Client, table: TableName):
+async def test_empty_string(client: Client, table: TableName, real_dynamo: bool):
+    if not real_dynamo:
+        pytest.xfail("empty strings not supported by dynalite yet")
     key = {"h": "h", "r": "r"}
     await client.put_item(table, {**key, "s": ""})
     assert await client.get_item(table, key) == {"h": "h", "r": "r"}
@@ -217,7 +220,7 @@ async def test_empty_string(client: Client, table: TableName):
 
 
 async def test_empty_item(client: Client, table: TableName):
-    with pytest.raises(EmptyItem):
+    with pytest.raises(ValidationException):
         await client.put_item(table, {"h": "", "r": ""})
 
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -210,13 +210,13 @@ async def test_empty_string(client: Client, table: TableName, real_dynamo: bool)
         pytest.xfail("empty strings not supported by dynalite yet")
     key = {"h": "h", "r": "r"}
     await client.put_item(table, {**key, "s": ""})
-    assert await client.get_item(table, key) == {"h": "h", "r": "r"}
+    assert await client.get_item(table, key) == {"h": "h", "r": "r", "s": ""}
     assert await client.update_item(
         table,
         key,
         F("foo").set("") & F("bar").set("baz"),
         return_values=ReturnValues.all_new,
-    ) == {"h": "h", "r": "r", "bar": "baz"}
+    ) == {"h": "h", "r": "r", "bar": "baz", "s": ""}
 
 
 async def test_empty_item(client: Client, table: TableName):


### PR DESCRIPTION
Fixes #48, removes special handling for empty strings and bytes.

Sadly, DynamoDB emulators seem to not yet support this so tests are marked as xfail for now.