### PR TITLE
Better client errors

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -7,7 +7,9 @@ Custom HTTP client adaptor
 If for some reason you want to use neither aiohttp nor httpx, you can adapt your
 own HTTP client for usage with aiodynamo. To do so, create a class that conforms
 to the :py:class:`aiodynamo.http.base.HTTP` interface. Errors should be wrapped in
-a :py:exc:`aiodynamo.http.base.RequestFailed`.
+a :py:exc:`aiodynamo.http.base.RequestFailed`. When raising a :py:exc:`aiodynamo.http.base.RequestFailed`
+due to an exception in the HTTP client, you **should explicitly chain the exceptions**
+using ``raise RequestFailed(reason) from client_exception``.
 
 .. autoclass:: aiodynamo.http.base.HTTP
     :members:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,6 +17,26 @@ The :py:class:`aiodynamo.client.Client` class takes three required and three opt
 5. Which numeric type to use. This should be a callable which accepts a string as input and returns your numeric type as output. Defaults to ``float``.
 6. The throttling configuration to use. An instance of :py:class:`aiodynamo.models.ThrottleConfig`. By default, if the DynamoDB rate limit is exceeded, aiodynamo will retry up for up to one minute with increasing delays.
 
+
+Credentials
+-----------
+
+In most cases, ``Credentials.auto()`` will load the credentials as you'd expect. Specifically, it will try multiple
+credentials providers in this order: :py:class:`aiodynamo.credentials.EnvironmentCredentials`,
+:py:class:`aiodynamo.credentials.ContainerMetadataCredentials` and :py:class:`aiodynamo.credentials.InstanceMetadataCredentials`.
+
+In case you want to explicitly pass the credentials from Python, use :py:class:`aiodynamo.credentials.StaticCredentials`.
+
+.. automethod:: aiodynamo.credentials.Credentials.auto
+
+.. autoclass:: aiodynamo.credentials.EnvironmentCredentials
+.. autoclass:: aiodynamo.credentials.ContainerMetadataCredentials
+.. autoclass:: aiodynamo.credentials.InstanceMetadataCredentials
+.. autoclass:: aiodynamo.credentials.ChainCredentials
+.. autoclass:: aiodynamo.credentials.StaticCredentials
+.. autoclass:: aiodynamo.credentials.Key
+
+
 The ``F`` class
 ---------------
 

--- a/src/aiodynamo/credentials.py
+++ b/src/aiodynamo/credentials.py
@@ -60,6 +60,20 @@ class Credentials(metaclass=abc.ABCMeta):
         """
 
 
+@dataclass(frozen=True)
+class StaticCredentials(Credentials):
+    key: Optional[Key]
+
+    async def get_key(self, http: HTTP) -> Optional[Key]:
+        return self.key
+
+    def invalidate(self) -> bool:
+        return False
+
+    def is_disabled(self) -> bool:
+        return False
+
+
 class ChainCredentials(Credentials):
     """
     Chains multiple credentials providers together, trying them

--- a/src/aiodynamo/credentials.py
+++ b/src/aiodynamo/credentials.py
@@ -62,6 +62,10 @@ class Credentials(metaclass=abc.ABCMeta):
 
 @dataclass(frozen=True)
 class StaticCredentials(Credentials):
+    """
+    Static credentials provided in Python.
+    """
+
     key: Optional[Key]
 
     async def get_key(self, http: HTTP) -> Optional[Key]:
@@ -242,6 +246,10 @@ def and_then(thing: Optional[T], mapper: Callable[[T], U]) -> Optional[U]:
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
 @dataclass
 class ContainerMetadataCredentials(MetadataCredentials):
+    """
+    Loads credentials from the ECS container metadata endpoint.
+    """
+
     timeout: Timeout = 2
     max_attempts: int = 3
     base_url: URL = URL("http://169.254.170.2")
@@ -296,6 +304,10 @@ class ContainerMetadataCredentials(MetadataCredentials):
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
 @dataclass
 class InstanceMetadataCredentials(MetadataCredentials):
+    """
+    Loads credentials from the EC2 instance metadata endpoint.
+    """
+
     timeout: Timeout = 1
     max_attempts: int = 1
     base_url: URL = URL("http://169.254.169.254")

--- a/src/aiodynamo/http/base.py
+++ b/src/aiodynamo/http/base.py
@@ -8,7 +8,11 @@ Headers = Mapping[str, str]
 
 
 class RequestFailed(Exception):
-    pass
+    reason: Optional[str]
+
+    def __init__(self, *args, reason: Optional[str] = None):
+        self.reason = reason
+        super().__init__(*args)
 
 
 class HTTP(metaclass=abc.ABCMeta):

--- a/src/aiodynamo/http/httpx.py
+++ b/src/aiodynamo/http/httpx.py
@@ -16,8 +16,8 @@ def wrap_errors(coro):
     async def wrapper(*args, **kwargs):
         try:
             return await coro(*args, **kwargs)
-        except HTTPError:
-            raise RequestFailed()
+        except HTTPError as exc:
+            raise RequestFailed("httpx HTTPError") from exc
 
     return wrapper
 
@@ -32,7 +32,9 @@ class HTTPX(HTTP):
     ) -> bytes:
         response = await self.client.get(str(url), headers=headers, timeout=timeout)
         if response.status_code >= 400:
-            raise RequestFailed()
+            raise RequestFailed(
+                f"httpx client status code > 400: {response.status_code}"
+            )
         return await response.aread()
 
     @wrap_errors

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -1,0 +1,40 @@
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+from aiodynamo.client import Client
+from aiodynamo.credentials import Key, StaticCredentials
+from aiodynamo.http.aiohttp import AIOHTTP
+from aiodynamo.http.base import RequestFailed
+from aiodynamo.models import ExponentialBackoffThrottling
+from yarl import URL
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def test_aiohttp_request_failed():
+    exc = asyncio.TimeoutError()
+
+    class FakeSession:
+        @asynccontextmanager
+        async def request(self, *args, **kwargs):
+            raise exc
+            yield
+
+    http = AIOHTTP(FakeSession())
+
+    with pytest.raises(RequestFailed) as error:
+        await http.get(url=URL("http://foo.invalid.com"), timeout=100)
+    assert error.value.__cause__ is exc
+
+    client = Client(
+        http=http,
+        credentials=StaticCredentials(Key("invalid", "invalid")),
+        region="invalid",
+        throttle_config=ExponentialBackoffThrottling(0),
+    )
+
+    with pytest.raises(RequestFailed) as error:
+        await client.get_item("table", {"key": "value"})
+
+    assert error.value.__cause__ is exc


### PR DESCRIPTION
Explicitly chains client errors (`RequestFailed`) and gives them an (optional) string reason.

Since I needed `StaticCredentials` for easy testing, I've added that too, as it can be handy. And since I touched Credentials, I've also improved their documentation. Sorry for the mixing of concerns.

Fixes #55