### PR TITLE
Add API to query/scan single DynamoDB pages

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -108,12 +108,30 @@ The ``Client`` class
 
     Aiodynamo handles pagination automatically, so this method returns an asynchronous iterator of items.
 
+    To only retrieve a single page, use :py:meth:`aiodynamo.client.Client.query_single_page`
+
+    .. seealso::
+        `Query - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html>`_.
+
+.. automethod:: aiodynamo.client.Client.query_single_page
+
+    Queries a single page from DynamoDB. To automatically handle pagination, use :py:meth:`aiodynamo.client.Client.query`
+
     .. seealso::
         `Query - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html>`_.
 
 .. automethod:: aiodynamo.client.Client.scan
 
     Aiodynamo handles pagination automatically, so this method returns an asynchronous iterator of items.
+
+    To only retrieve a single page, use :py:meth:`aiodynamo.client.Client.scan_single_page`
+
+    .. seealso::
+        `Scan - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html>`_.
+
+.. automethod:: aiodynamo.client.Client.scan_single_page
+
+    Scans a single page from DynamoDB. To automatically handle pagination, use :py:meth:`aiodynamo.client.Client.scan`
 
     .. seealso::
         `Scan - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html>`_.
@@ -174,12 +192,30 @@ Methods
 
     Aiodynamo handles pagination automatically, so this method returns an asynchronous iterator of items.
 
+    To only retrieve a single page, use :py:meth:`aiodynamo.client.Table.query_single_page`
+
+    .. seealso::
+        `Query - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html>`_.
+
+.. automethod:: aiodynamo.client.Table.query_single_page
+
+    Queries a single page from DynamoDB. To automatically handle pagination, use :py:meth:`aiodynamo.client.Table.query`
+
     .. seealso::
         `Query - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html>`_.
 
 .. automethod:: aiodynamo.client.Table.scan
 
     Aiodynamo handles pagination automatically, so this method returns an asynchronous iterator of items.
+
+    To only retrieve a single page, use :py:meth:`aiodynamo.client.Table.scan_single_page`
+
+    .. seealso::
+        `Scan - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html>`_.
+
+.. automethod:: aiodynamo.client.Table.scan_single_page
+
+    Scans a single page from DynamoDB. To automatically handle pagination, use :py:meth:`aiodynamo.client.Table.scan`
 
     .. seealso::
         `Scan - DynamoDB API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html>`_.

--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from enum import Enum, unique
 from itertools import count
 from typing import (
+    Any,
     AsyncIterable,
     AsyncIterator,
     Dict,
@@ -27,6 +28,7 @@ from .types import (
     EncodedProjection,
     EncodedStreamSpecification,
     EncodedThroughput,
+    Item,
     Timespan,
 )
 
@@ -247,3 +249,13 @@ class ExponentialBackoffThrottling(ThrottleConfig):
             yield min(
                 random.random() * (self.base_delay_secs ** attempt), self.max_delay_secs
             )
+
+
+@dataclass(frozen=True)
+class Page:
+    items: List[Item]
+    last_evaluated_key: Optional[Dict[str, Any]]
+
+    @property
+    def is_last_page(self) -> bool:
+        return self.last_evaluated_key is None

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+from operator import itemgetter
 
 import pytest
 from yarl import URL
@@ -7,7 +8,6 @@ from aiodynamo import errors
 from aiodynamo.client import Client, TimeToLiveStatus
 from aiodynamo.credentials import ChainCredentials
 from aiodynamo.errors import (
-    EmptyItem,
     ItemNotFound,
     NoCredentialsFound,
     TableNotFound,
@@ -272,6 +272,32 @@ async def test_query_with_limit(client: Client, high_throughput_table: TableName
     ]
     assert len(items) == 1
     assert items[0]["r"] == "0"
+
+
+async def test_query_single_page(client: Client, high_throughput_table: TableName):
+    big = "x" * 20_000
+
+    await asyncio.gather(
+        *(
+            client.put_item(high_throughput_table, {"h": "h", "r": str(i), "big": big})
+            for i in range(100)
+        )
+    )
+
+    first_page = await client.query_single_page(
+        high_throughput_table, HashKey("h", "h")
+    )
+    assert first_page.items
+    assert first_page.last_evaluated_key
+    assert not first_page.is_last_page
+    second_page = await client.query_single_page(
+        high_throughput_table,
+        HashKey("h", "h"),
+        start_key=first_page.last_evaluated_key,
+    )
+    assert not set(map(itemgetter("r"), first_page.items)) & set(
+        map(itemgetter("r"), second_page.items)
+    )
 
 
 async def test_scan_with_limit(client: Client, table: TableName):


### PR DESCRIPTION
Adds two new APIs to both `Client` and `Table`: `query_single_page` and `scan_single_page`, both taking the same arguments as `query` and `scan` respectively. Unlike `query` and `scan`, they do not return an async iterator over items, but instead a `Page` which has a `List` of items and the `LastEvaluatedKey`. They can be used in cases where manual de-pagination is desired, such as returning items from DynamoDB via a paginated API.