### PR TITLE
Count limits

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+Release Date: UNRELEASED
+
+* Added the `limit` parameter to :py:meth:`aiodynamo.client.Client.count`
+
 21.8
 ----
 

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -923,7 +923,8 @@ class Client:
                     task = None
                 else:
                     if limit is not None:
-                        limit = limit - res["Count"] if is_count else len(res["Items"])
+                        consumed: int = res["Count"] if is_count else len(res["Items"])
+                        limit -= consumed
                         if limit > 0:
                             payload["Limit"] = limit
                         else:

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -923,7 +923,7 @@ class Client:
                     task = None
                 else:
                     if limit is not None:
-                        limit -= res["Count"] if is_count else len(res["Items"])
+                        limit = limit - res["Count"] if is_count else len(res["Items"])
                         if limit > 0:
                             payload["Limit"] = limit
                         else:

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -913,17 +913,19 @@ class Client:
         is_count = payload.get("Select") == "COUNT"
         try:
             while task:
-                res = await task
+                result = await task
                 try:
                     payload = {
                         **payload,
-                        "ExclusiveStartKey": res["LastEvaluatedKey"],
+                        "ExclusiveStartKey": result["LastEvaluatedKey"],
                     }
                 except KeyError:
                     task = None
                 else:
                     if limit is not None:
-                        consumed: int = res["Count"] if is_count else len(res["Items"])
+                        consumed: int = (
+                            result["Count"] if is_count else len(result["Items"])
+                        )
                         limit -= consumed
                         if limit > 0:
                             payload["Limit"] = limit
@@ -933,7 +935,7 @@ class Client:
                     task = asyncio.create_task(
                         self.send_request(action=action, payload=payload)
                     )
-                yield res
+                yield result
         except asyncio.CancelledError:
             if task:
                 task.cancel()

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -90,6 +90,7 @@ async def test_count(client: Client, table: TableName):
         await client.count(table, HashKey("h", "h1") & RangeKey("r").begins_with("x"))
         == 0
     )
+    await client.count(table, HashKey("h", "h2"), limit=1) == 1
 
 
 async def test_update_item(client: Client, table: TableName):

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -90,7 +90,20 @@ async def test_count(client: Client, table: TableName):
         await client.count(table, HashKey("h", "h1") & RangeKey("r").begins_with("x"))
         == 0
     )
-    await client.count(table, HashKey("h", "h2"), limit=1) == 1
+
+
+async def test_count_with_limit(client: Client, table: TableName):
+    hk = HashKey("h", "k")
+    assert await client.count(table, hk, limit=1) == 0
+    await client.put_item(table, {"h": "k", "r": "0"})
+    for i in range(1, 20):
+        assert await client.count(table, hk, limit=30) == i
+        assert await client.count(table, hk, limit=i) == i
+
+        await client.put_item(table, {"h": "k", "r": str(i)})
+
+        assert await client.count(table, hk, limit=i) == i
+        assert await client.count(table, hk, limit=i + 1) == i + 1
 
 
 async def test_update_item(client: Client, table: TableName):


### PR DESCRIPTION
This was motivated by our real-life use case. We sometimes need to limit counting to preserve latency and Dynamo resources. I tried using `query_single_page` but it doesn't support count queries, so I just added `limit` to `count`.