### PR TITLE
use httpx content= parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = ["dynamodb", "asyncio", "aws"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-httpx = {version = ">=0.11.1 <1.0.0", optional = true}
+httpx = {version = ">=0.15.0 <1.0.0", optional = true}
 aiohttp = {version = "^3.6.2", optional = true}
 yarl = "^1.4.2"
 typing_extensions = { version = "^3.7", python = "< 3.8" }

--- a/src/aiodynamo/http/httpx.py
+++ b/src/aiodynamo/http/httpx.py
@@ -42,7 +42,7 @@ class HTTPX(HTTP):
         with wrap_errors():
             # FIXME: the `or {}` is not needed but httpx type hints are wrong
             response = await self.client.post(
-                str(url), data=body, headers=headers or {}
+                str(url), content=body, headers=headers or {}
             )
             if response.status_code >= 400:
                 raise exception_from_response(


### PR DESCRIPTION
`content=<bytes>` was introduced in httpx `0.15.0 (September 22nd, 2020)`

`data=<bytes>` was deprecated in httpx `0.18.0 (27th April, 2021)`
