### PR TITLE
Add support for pay_per_request billing mode during table creation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,6 +72,8 @@ The ``Client`` class
 
     If ``wait_for_active`` is set to ``True``, it will wait until the table status changed into ``Active``.
     If after the defined wait time the table is not active, an exception will be raised.
+    Passing a :py:class:`aiodynamo.models.PayPerRequest` object in place of a :py:class:`aiodynamo.models.Throughput`
+    configuration will create a ``PAY_PER_REQUEST`` BillingMode table.
 
     .. seealso::
         `CreateTable - AWS API documentation <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html>`_.
@@ -327,6 +329,9 @@ Key conditions are created using the :py:class:`aiodynamo.expressions.HashKey` a
 
 Models
 ------
+.. autoclass:: aiodynamo.models.PayPerRequest
+    :undoc-members:
+
 .. autoclass:: aiodynamo.models.Throughput
     :members: read, write
     :undoc-members:

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -42,6 +42,7 @@ from .models import (
     KeyType,
     LocalSecondaryIndex,
     Page,
+    PayPerRequest,
     ReturnValues,
     Select,
     StreamSpecification,
@@ -90,7 +91,7 @@ class Table:
 
     async def create(
         self,
-        throughput: Throughput,
+        throughput: Union[Throughput, PayPerRequest],
         keys: KeySchema,
         *,
         lsis: Optional[List[LocalSecondaryIndex]] = None,
@@ -334,7 +335,7 @@ class Client:
     async def create_table(
         self,
         name: TableName,
-        throughput: Throughput,
+        throughput: Union[Throughput, PayPerRequest],
         keys: KeySchema,
         *,
         lsis: Optional[List[LocalSecondaryIndex]] = None,
@@ -353,11 +354,11 @@ class Client:
             {"AttributeName": key, "AttributeType": value}
             for key, value in attributes.items()
         ]
-        payload = {
+        payload: Dict[str, Any] = {
             "AttributeDefinitions": attribute_definitions,
             "TableName": name,
             "KeySchema": keys.encode(),
-            "ProvisionedThroughput": throughput.encode(),
+            **throughput.encode(),
         }
         if lsis:
             payload["LocalSecondaryIndexes"] = [index.encode() for index in lsis]

--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -26,6 +26,7 @@ from .types import (
     EncodedGlobalSecondaryIndex,
     EncodedKeySchema,
     EncodedLocalSecondaryIndex,
+    EncodedPayPerRequest,
     EncodedProjection,
     EncodedStreamSpecification,
     EncodedThroughput,
@@ -57,7 +58,19 @@ class Throughput:
     write: int
 
     def encode(self) -> EncodedThroughput:
-        return {"ReadCapacityUnits": self.read, "WriteCapacityUnits": self.write}
+        return {
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": self.read,
+                "WriteCapacityUnits": self.write,
+            }
+        }
+
+
+class PayPerRequest:
+    MODE: str = "PAY_PER_REQUEST"
+
+    def encode(self) -> EncodedPayPerRequest:
+        return {"BillingMode": self.MODE}
 
 
 class KeyType(Enum):

--- a/src/aiodynamo/types.py
+++ b/src/aiodynamo/types.py
@@ -38,9 +38,17 @@ class AttributeType(Enum):
     map = "M"
 
 
-class EncodedThroughput(TypedDict):
+class EncodedThroughputData(TypedDict):
     ReadCapacityUnits: int
     WriteCapacityUnits: int
+
+
+class EncodedThroughput(TypedDict):
+    ProvisionedThroughput: EncodedThroughputData
+
+
+class EncodedPayPerRequest(TypedDict):
+    BillingMode: str
 
 
 class EncodedKeySchema(TypedDict):


### PR DESCRIPTION
Currently aiodynamo creates tables using the provisioned billing mode. DynamoDB also supports pay_per_request where no throughput config is provided. This PR is backwards compatible, but also adds the support to provide a `billing_mode` parameter to `create_table`. The `throughput` parameter has been changed to optional as the pay_per_request billing mode doesn't use it.

PS. I'd be very grateful if you could also add the `hacktoberfest-accepted` label to this PR once it is accepted so that it can be counted as a hacktoberfest PR. Thanks :)