### PR TITLE
Speedup tests, test Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,17 @@
 version: 2.1
+executors:
+  python:
+    parameters:
+      version:
+        type: string
+    docker:
+      - image: python:<< parameters.version >>
+        environment:
+          DYNAMODB_URL: http://localhost:8000
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+      - image: dimaqq/dynalite:latest
+    working_directory: /home/ubuntu/aiodynamo
 commands:
   runtests:
     steps:
@@ -17,36 +30,27 @@ commands:
           path: reports/results/
 jobs:
   py37:
-    docker:
-      - image: python:3.7
-        environment:
-          DYNAMODB_URL: http://localhost:8000
-          AWS_ACCESS_KEY_ID: dummy
-          AWS_SECRET_ACCESS_KEY: dummy
-      - image: dimaqq/dynalite:latest
-    working_directory: /home/ubuntu/aiodynamo
+    executor:
+      name: python
+      version: "3.7"
     steps:
       - runtests
   py38:
-    docker:
-      - image: python:3.8
-        environment:
-          DYNAMODB_URL: http://localhost:8000
-          AWS_ACCESS_KEY_ID: dummy
-          AWS_SECRET_ACCESS_KEY: dummy
-      - image: dimaqq/dynalite:latest
-    working_directory: /home/ubuntu/aiodynamo
+    executor:
+      name: python
+      version: "3.8"
     steps:
       - runtests
   py39:
-    docker:
-      - image: python:3.9
-        environment:
-          DYNAMODB_URL: http://localhost:8000
-          AWS_ACCESS_KEY_ID: dummy
-          AWS_SECRET_ACCESS_KEY: dummy
-      - image: dimaqq/dynalite:latest
-    working_directory: /home/ubuntu/aiodynamo
+    executor:
+      name: python
+      version: "3.9"
+    steps:
+      - runtests
+  py310:
+    executor:
+      name: python
+      version: "3.10"
     steps:
       - runtests
 workflows:
@@ -55,3 +59,4 @@ workflows:
       - py37
       - py38
       - py39
+      - py310


### PR DESCRIPTION
Made a session-scoped pytest fixture with a "multi-page" dynamodb table.
This should speed up the tests as it does not need to re-build the table
for each test requiring lots of items.