### PR TITLE
handle ResourceInUseException

### DIFF
--- a/src/aiodynamo/errors.py
+++ b/src/aiodynamo/errors.py
@@ -64,6 +64,10 @@ class TableInUse(AIODynamoError):
     pass
 
 
+class ResourceInUse(AIODynamoError):
+    pass
+
+
 class GlobalTableAlreadyExists(AIODynamoError):
     pass
 
@@ -173,6 +177,7 @@ ERRORS = {
     "ThrottlingException": Throttled,
     "ValidationException": ValidationException,
     "ExpiredTokenException": ExpiredToken,
+    "ResourceInUseException": ResourceInUse,
 }
 
 


### PR DESCRIPTION
For #70 

`ResourceInUseException` is returned when trying to create a table that already exists... (maybe the assumption is that table is being used right now).
ran into this with `dynalite`.