### PR TITLE
Add __eq__ and __repr__ to aiodynamo.expressions.F

### DIFF
--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -71,3 +71,25 @@ def test_hash_key_encoding(hash_key, encoded, ean, eav):
     payload = params.to_request_payload()
     assert payload["ExpressionAttributeNames"] == ean
     assert payload["ExpressionAttributeValues"] == eav
+
+
+@pytest.mark.parametrize(
+    "lhs,rhs,eq",
+    [
+        (F("foo"), F("foo"), True),
+        (F("foo"), F("bar"), False),
+        (F("foo"), True, False),
+        (F("foo", 1, "bar"), F("foo", 1, "bar"), True),
+        (F("foo", 1, "bar"), F("foo", 2, "bar"), False),
+        (F("foo", 1, "bar"), F("foo", 1, "baz"), False),
+    ],
+)
+def test_f_eq(lhs, rhs, eq):
+    assert (lhs == rhs) is eq
+
+
+@pytest.mark.parametrize(
+    "f,r", [(F("foo"), "F(foo)"), (F("foo", 1, "bar"), "F(foo.1.bar)")]
+)
+def test_f_repr(f, r):
+    assert repr(f) == r


### PR DESCRIPTION
Fixes #110 

Instances of F can now be compared for equality if their paths match and
provide a reasonable repr.
The changes to UpdateExpression included here are because implementing
__eq__ for F means that setting the same field twice in an update
expresssion would ignore one of the values. This changes the behaviour
of `F("a").set("a") & F("a").set("b")` which currently raises a
(DynamoDB-side) error, but no longer raised one after implementing
__eq__. Switching from Dict[F, T] to List[Tuple[F, T]] preserves the
current behaviour and invalid update expressions correctly raise an
error.