### PR TITLE
[BENCH_]RANGE_KEY_NAME was not used

### DIFF
--- a/benchmarks/query/README.md
+++ b/benchmarks/query/README.md
@@ -56,7 +56,6 @@ export BENCH_TABLE_NAME="foobar"
 export BENCH_KEY_FIELD="foobar"
 export BENCH_KEY_VALUE="foobar"
 export BENCH_REGION_NAME="us-east-1"
-export BENCH_RANGE_KEY_NAME="quux"
 ```
 
 A script `fill_db.py` is provided to fill up one shard in this table.

--- a/benchmarks/query/fill_db.py
+++ b/benchmarks/query/fill_db.py
@@ -7,13 +7,12 @@ from pyperf import Runner
 from aiodynamo.client import Client, URL
 from aiodynamo.credentials import Credentials
 from aiodynamo.http.aiohttp import AIOHTTP
-from utils import TABLE_NAME, KEY_FIELD, KEY_VALUE, REGION_NAME, ENDPOINT_URL, RANGE_KEY_NAME
+from utils import TABLE_NAME, KEY_FIELD, KEY_VALUE, REGION_NAME, ENDPOINT_URL
 
 
 DUMP = {f"field-%i": f"value-%i" for i in range(100)}
 
 async def inner():
-    assert RANGE_KEY_NAME, "Please provide `BENCH_RANGE_KEY_NAME` environment variable"
     async with ClientSession() as session:
         client = Client(
             AIOHTTP(session),

--- a/benchmarks/query/utils.py
+++ b/benchmarks/query/utils.py
@@ -5,4 +5,3 @@ KEY_FIELD = os.environ["BENCH_KEY_FIELD"]
 KEY_VALUE = os.environ["BENCH_KEY_VALUE"]
 REGION_NAME = os.environ["BENCH_REGION_NAME"]
 ENDPOINT_URL = os.environ.get("BENCH_ENDPOINT_URL")
-RANGE_KEY_NAME = os.environ.get("BENCH_RANGE_KEY_NAME")


### PR DESCRIPTION
- drop unused RNAGE_KEY_NAME in benchmarks
- fix the data filler