### PR TITLE
Raise asyncio.TimeoutError on httpx.TimeoutException

### DIFF
--- a/src/aiodynamo/http/httpx.py
+++ b/src/aiodynamo/http/httpx.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, cast
 
+import asyncio
 import httpx
 
 from .types import Request, RequestFailed, Response
@@ -20,5 +21,7 @@ class HTTPX:
                 content=cast(bytes, request.body),
             )
             return Response(response.status_code, await response.aread())
+        except httpx.TimeoutException:
+            raise asyncio.TimeoutError()
         except httpx.HTTPError as exc:
             raise RequestFailed(exc)


### PR DESCRIPTION
Now `asyncio.TimeoutError` is handled in the client logic. But `httpx` wrapper raises `httpx.TimeoutException`.
This pull request convert the exception and make the client be able to handle timeouts in `httpx`.

ref.) `httpx` timeout exceptions
https://github.com/encode/httpx/blob/master/httpx/_exceptions.py#L7-L11

ref.) Custom HTTP Client Adaptor document
https://github.com/HENNGE/aiodynamo/blob/2e6c4716a3ac9fe5669bbdcaa73e6bbe0f73cfbb/docs/advanced.rst