### PR TITLE
Add kubernetes credentials to the list of possible credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ python = "^3.7"
 httpx = {version = ">=0.15.0 <1.0.0", optional = true}
 aiohttp = {version = "^3.6.2", optional = true}
 yarl = "^1.4.2"
-typing_extensions = { version = "^3.7", python = "< 3.8" }
+typing_extensions = { version = "^4.2", python = "< 3.8" }
 
 [tool.poetry.extras]
 httpx = ["httpx"]
@@ -44,6 +44,7 @@ mypy = "0.931"
 pyfakefs = "^4.3.2"
 isort = "^5.8.0"
 types-freezegun = "^1.1.6"
+boto3-stubs = "^1.24.18"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,10 +4,7 @@ from functools import partial
 from typing import Any, Callable, Dict
 
 import pytest
-from boto3.dynamodb.types import (  # type: ignore[import]
-    DYNAMODB_CONTEXT,
-    TypeDeserializer,
-)
+from boto3.dynamodb.types import DYNAMODB_CONTEXT, TypeDeserializer
 
 from aiodynamo.types import NumericTypeConverter
 from aiodynamo.utils import deserialize, dy2py
@@ -66,7 +63,7 @@ def test_serde_compatibility() -> None:
 
     item = generate_item(True)
 
-    class BinaryDeserializer(TypeDeserializer):  # type: ignore[misc]
+    class BinaryDeserializer(TypeDeserializer):
         def _deserialize_b(self, value: Any) -> bytes:
             return base64.b64decode(value)
 


### PR DESCRIPTION
We've been using AioDynamo for a while in my current company. The existing credentials work pretty well with ECS and EC2 machines. However, when running inside a Kubernetes cluster (like EKS), the metadata from the EC2 instance is not available and we don't have the credentials from AWS as environment variables because our pod basically assumes a role on AWS. We also don't have a file with credentials or anything like that. That said, we needed a way to fetch the credentials from AWS that our pod has, and luckily AWS offers us a way to do that by calling `get_credentials`.

This PR does the following:

1. Creates a new `KubernetesCredentials`;
2. Updates typing-extensions to support the most recent version;
3. Add boto3-stubs to our dev dependencies;