### PR TITLE
Support typed exceptions with dynamodb-local.

### DIFF
--- a/src/aiodynamo/errors.py
+++ b/src/aiodynamo/errors.py
@@ -207,7 +207,7 @@ def exception_from_response(status: int, body: bytes) -> Exception:
         return ServiceUnavailable()
     try:
         data = json.loads(body)
-        error = ERRORS[data["__type"].split("#", 1)[1]](data)
+        error = ERRORS[data["__type"].split("#", 1)[-1]](data)
         if isinstance(error, TransactionCanceled):
             error = extract_error_from_transaction_canceled(data)
         return error
@@ -220,4 +220,4 @@ def extract_error_from_transaction_canceled(data: Dict[str, Any]) -> AIODynamoEr
         error = data["CancellationReasons"][0]
         return ERRORS[f"{error['Code']}Exception"](error["Message"])
     except Exception:
-        return ERRORS[data["__type"].split("#", 1)[1]](data)
+        return ERRORS[data["__type"].split("#", 1)[-1]](data)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -30,14 +30,16 @@ async def test_retry_raises_underlying_error_aiohttp() -> None:
         await client.get_item("test", {"a": "b"})
 
 
-async def test_dynamo_errors_get_raised_depaginated() -> None:
+# dynamodb-local does non include the #-prefixed value
+@pytest.mark.parametrize("error_type", ["ValidationException", "com.amazonaws.dynamodb.v20120810#ValidationException"])
+async def test_dynamo_errors_get_raised_depaginated(error_type: str) -> None:
     class TestResponse:
         status = 400
 
         async def read(self) -> bytes:
             return json.dumps(
                 {
-                    "__type": "com.amazonaws.dynamodb.v20120810#ValidationException",
+                    "__type": error_type,
                     "message": "test",
                 }
             ).encode()


### PR DESCRIPTION
The value of the __type key in body of the error responses from dynamodb local does not have the com.amazonaws.dynamodb.v20120810# prefix.

An example of a ConditionalCheckFailedException:

```
{"__type": "ConditionalCheckFailedException", "message": "The conditional request failed"}
````