### PR TITLE
add AWS_PROFILE env var to credentials chain

### DIFF
--- a/src/aiodynamo/credentials.py
+++ b/src/aiodynamo/credentials.py
@@ -9,7 +9,7 @@ import os
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
-from typing import Callable, Optional, Sequence, TypeVar
+from typing import Callable, Optional, Sequence, TypeVar, cast
 
 from yarl import URL
 
@@ -158,8 +158,10 @@ class FileCredentials(Credentials):
         self,
         *,
         path: Optional[Path] = None,
-        profile_name: str = "default",
+        profile_name: Optional[str] = None,
     ) -> None:
+        if profile_name is None:
+            profile_name = cast(str, os.environ.get("AWS_PROFILE", "default"))
         if path is None:
             path = Path.home().joinpath(".aws", "credentials")
         self.key = None

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -180,7 +180,9 @@ async def test_disabled(monkeypatch: MonkeyPatch) -> None:
     assert not creds.is_disabled()
 
 
-async def test_file_credentials(fs: FakeFilesystem, http: HttpImplementation) -> None:
+async def test_file_credentials(
+    fs: FakeFilesystem, http: HttpImplementation, monkeypatch: MonkeyPatch
+) -> None:
     assert FileCredentials().is_disabled()
     fs.create_file(
         Path.home().joinpath(".aws", "credentials"),
@@ -201,6 +203,11 @@ async def test_file_credentials(fs: FakeFilesystem, http: HttpImplementation) ->
     credentials = FileCredentials(profile_name="my-profile")
     assert not credentials.is_disabled()
     assert await credentials.get_key(http) == Key(id="baz", secret="hoge")
+    monkeypatch.setenv("AWS_PROFILE", "my-profile")
+    credentials = FileCredentials()
+    assert not credentials.is_disabled()
+    assert await credentials.get_key(http) == Key(id="baz", secret="hoge")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
     custom_path = Path("/custom/credentials/file")
     assert FileCredentials(path=custom_path).is_disabled()
     fs.create_file(


### PR DESCRIPTION
Adds support for using AWS_PROFILE env var in the credentials chain.  
This behavior is more in line with the behavior expected by users coming from boto3 or aiobotocore.
Added a unit test to cover this feature.

Relates to: Issue #139 