### PR TITLE
Fix poetry lock running forever

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ typing_extensions = { version = "^3.7", python = "< 3.8" }
 httpx = ["httpx"]
 aiohttp = ["aiohttp"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^6.0"
 pytest-asyncio = "^0.17"
 pytest-cov = "^2.6"
@@ -44,6 +44,7 @@ mypy = "^0.971"
 pyfakefs = "^4.3.2"
 isort = "^5.8.0"
 types-freezegun = "^1.1.6"
+urllib3 = "< 1.27"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -64,5 +65,5 @@ files = [
 ]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Dependency resolution took a long time because poetry chose the wrong version of urllib3.
Specifying the urllib3 version solve the resolution.