### PR TITLE
Properly support creating pay-per-request tables

### DIFF
--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -8,7 +8,17 @@ import time
 from dataclasses import dataclass
 from enum import Enum, unique
 from itertools import count
-from typing import Any, AsyncIterable, Dict, Iterable, Iterator, List, Optional, cast
+from typing import (
+    Any,
+    AsyncIterable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    cast,
+    Union,
+)
 
 from .expressions import Parameters, ProjectionExpression
 from .types import (
@@ -132,12 +142,19 @@ class GlobalSecondaryIndex(LocalSecondaryIndex):
     throughput: Optional[Throughput]
 
     def encode(self) -> EncodedGlobalSecondaryIndex:
+        # Writing this as an inline terary doesn't satisfy MyPy
+        # error: Missing key "ProvisionedThroughput" for TypedDict "EncodedThroughput"
+        t: Union[EncodedThroughput, dict[Any, Any]]
+        if self.throughput:
+            t = self.throughput.encode()
+        else:
+            t = {}
         # Cast due to https://github.com/python/mypy/issues/4122
         return cast(
             EncodedGlobalSecondaryIndex,
             {
                 **super().encode(),
-                **(self.throughput.encode() if self.throughput else {}),
+                **cast(EncodedThroughput, t),
             },
         )
 

--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -129,13 +129,13 @@ class LocalSecondaryIndex:
 
 @dataclass(frozen=True)
 class GlobalSecondaryIndex(LocalSecondaryIndex):
-    throughput: Throughput
+    throughput: Optional[Throughput]
 
     def encode(self) -> EncodedGlobalSecondaryIndex:
         # Cast due to https://github.com/python/mypy/issues/4122
         return cast(
             EncodedGlobalSecondaryIndex,
-            {**super().encode(), **self.throughput.encode()},
+            {**super().encode(), **self.throughput.encode() if self.throughput else {}},
         )
 
 

--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -135,7 +135,10 @@ class GlobalSecondaryIndex(LocalSecondaryIndex):
         # Cast due to https://github.com/python/mypy/issues/4122
         return cast(
             EncodedGlobalSecondaryIndex,
-            {**super().encode(), **(self.throughput.encode() if self.throughput else {})},
+            {
+                **super().encode(),
+                **(self.throughput.encode() if self.throughput else {}),
+            },
         )
 
 

--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -135,7 +135,7 @@ class GlobalSecondaryIndex(LocalSecondaryIndex):
         # Cast due to https://github.com/python/mypy/issues/4122
         return cast(
             EncodedGlobalSecondaryIndex,
-            {**super().encode(), **self.throughput.encode() if self.throughput else {}},
+            {**super().encode(), **(self.throughput.encode() if self.throughput else {})},
         )
 
 

--- a/src/aiodynamo/types.py
+++ b/src/aiodynamo/types.py
@@ -67,7 +67,7 @@ class EncodedLocalSecondaryIndex(TypedDict):
     Projection: EncodedProjection
 
 
-class EncodedGlobalSecondaryIndex(EncodedLocalSecondaryIndex):
+class EncodedGlobalSecondaryIndex(EncodedLocalSecondaryIndex, total=False):
     ProvisionedThroughput: EncodedThroughput
 
 

--- a/src/aiodynamo/types.py
+++ b/src/aiodynamo/types.py
@@ -1,6 +1,6 @@
 import decimal
 from enum import Enum
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Union, Optional
 
 from ._compat import TypedDict
 
@@ -68,7 +68,7 @@ class EncodedLocalSecondaryIndex(TypedDict):
 
 
 class EncodedGlobalSecondaryIndex(EncodedLocalSecondaryIndex, total=False):
-    ProvisionedThroughput: EncodedThroughput
+    ProvisionedThroughput: Optional[EncodedThroughput]
 
 
 class EncodedStreamSpecificationRequired(TypedDict):


### PR DESCRIPTION
When creating a table in pay-per-request billing mode, don't specify provisioned throughput for GSIs.

It might be better to create two classes of the Table type, one for each billing mode. But that's a major (probably breaking) refactor, and the AWS API doesn't do this either.