### PR TITLE
Upgrade dependencies, drop 3.7 support, add 3.11 support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
     needs: lock
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: "ubuntu-latest"
     services:
       dynalite:
@@ -53,7 +53,7 @@ jobs:
     needs: lock
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: "ubuntu-latest"
     services:
       dynamodb:
@@ -81,7 +81,7 @@ jobs:
     needs: lock
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: "ubuntu-latest"
     services:
       dynamodb:
@@ -109,7 +109,7 @@ jobs:
     needs: lock
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
@@ -131,11 +131,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: actions/cache@v2
         with:
           path: poetry.lock
-          key: ${{ github.sha }}-3.10
+          key: ${{ github.sha }}-3.11
       - run: curl -sSL https://install.python-poetry.org | python3 -
       - run: poetry install --extras aiohttp --extras httpx
       - run: poetry run isort --check --diff src tests
@@ -147,11 +147,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: actions/cache@v2
         with:
           path: poetry.lock
-          key: ${{ github.sha }}-3.10
+          key: ${{ github.sha }}-3.11
       - run: curl -sSL https://install.python-poetry.org | python3 -
       - run: poetry install --extras aiohttp --extras httpx
       - run: poetry run black --check src/ tests/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -77,7 +77,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -173,3 +173,5 @@ epub_title = project
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ["search.html"]
+
+maximum_signature_line_length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/HENNGE/aiodynamo"
 documentation = "https://aiodynamo.readthedocs.io"
 classifiers = [
     "Framework :: AsyncIO",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3 :: Only",
     "Typing :: Typed",
     "License :: OSI Approved :: Apache Software License",
@@ -21,11 +21,10 @@ homepage = "https://github.com/HENNGE/aiodynamo"
 keywords = ["dynamodb", "asyncio", "aws"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 httpx = {version = ">=0.15.0 <1.0.0", optional = true}
 aiohttp = {version = "^3.6.2", optional = true}
 yarl = "^1.4.2"
-typing_extensions = { version = "^3.7", python = "< 3.8" }
 
 [tool.poetry.extras]
 httpx = ["httpx"]
@@ -36,7 +35,7 @@ pytest = "^6.0"
 pytest-asyncio = "^0.17"
 pytest-cov = "^2.6"
 black = "^22.3"
-sphinx = "^4.3"
+sphinx = "^7"
 pyperf = "^2.0"
 boto3 = "^1.12.18"
 freezegun = "^1.0"


### PR DESCRIPTION
3.7 is EOL'd

Sphinx upgrade makes it so our complex signatures look _a lot_ better than before.

Old:

<img width="737" alt="Screenshot 2023-10-02 at 17 27 46" src="https://github.com/HENNGE/aiodynamo/assets/141122/fc386581-65f7-48ce-a1d6-85df25b6590f">

New:

<img width="873" alt="Screenshot 2023-10-02 at 17 28 03" src="https://github.com/HENNGE/aiodynamo/assets/141122/37e2a201-8b03-4431-93c0-73f511f15365">
