### PR TITLE
Add GHA for PyPi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: aiodynamo release workflow
+
+on:
+  release:
+    types: [released] # only triggered on release, not pre-release or draft release
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PYTHON_VERSION_MIN: 3.8
+  TARGET_BRANCH: ${{ github.event.release.target_commitish }}
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+  TAG_NAME: ${{ github.ref_name }}
+
+jobs:
+  release:
+    name: Release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether release target branch is default branch
+        if: env.TARGET_BRANCH != env.DEFAULT_BRANCH
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('Target branch (${{ env.TARGET_BRANCH }}) is not default branch (${{ env.DEFAULT_BRANCH }}).')
+      
+      - uses: actions/checkout@v3
+      
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION_MIN }}
+          
+      - run: curl -sSL https://install.python-poetry.org | python3 -
+      
+      - run: echo "PKG_VER=$(poetry version --short)" >> $GITHUB_ENV
+      
+      - name: Check whether current tag matches package version
+        if: env.TAG_NAME != env.PKG_VER
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('Tag name (${{ env.TAG_NAME }}) does not match package version (${{ env.PKG_VER }}).')
+      
+      - name: Build package
+        run: poetry build
+        
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION_MIN }}
+          python-version: ${{ env.PYTHON_VERSION }}
           
       - run: curl -sSL https://install.python-poetry.org | python3 -
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 env:
-  PYTHON_VERSION_MIN: 3.8
+  PYTHON_VERSION: 3.11
   TARGET_BRANCH: ${{ github.event.release.target_commitish }}
   DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
As with AAPNS, this will automatically publish a new pypi release when a Github release is created.