### PR TITLE
Fix timing bug in Refreshable, optimize ChainCredentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,5 +33,5 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
-        args: ['check', 'src', 'tests']
+        args: ['check', '--fix', 'src', 'tests']
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+23.10.1
+-------
+
+* Fixed issue with refreshable credentials not working due to timing issue introduced in 23.10.
+* Improved performance of :py:class:`aiodynamo.credentials.ChainCredentials`
+
 23.10
 -----
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import Any, Callable, Dict
 
 import pytest
-from boto3.dynamodb.types import (  # type: ignore[import]
+from boto3.dynamodb.types import (  # type: ignore[import-untyped]
     DYNAMODB_CONTEXT,
     TypeDeserializer,
 )


### PR DESCRIPTION
Refreshable had a timing bug where refreshing the token could result in an invalid state if invalidate() was called at the same time. This is due to the Event Loop being able to schedule other coroutines to run between the current value being set in _refresh() and the value being checked in get(). By moving the assignment from _refresh() to get(), no other coroutines can run between the setting and checking, preventing the class from ending up in an invalid state.

ChainCredentials would needlessly check many candidates every time, even if it had already done so previously. Since running code cannot move to different environments, this check is unneccessary and inefficient, so instead ChainCredentials now remembers when a provider has succeeded and will only try that one again.