### PR TITLE
Flatten AND and OR conditions

### DIFF
--- a/src/aiodynamo/expressions.py
+++ b/src/aiodynamo/expressions.py
@@ -382,6 +382,8 @@ class Condition(metaclass=abc.ABCMeta):
                 return AndCondition(self.children.extending(other.children))
             else:
                 return AndCondition(self.children.appending(other))
+        elif isinstance(other, AndCondition):
+            return AndCondition(other.children.prepending(self))
         return AndCondition(MinLen2AppendOnlyList.create(self, other))
 
     def __or__(self, other: Condition) -> Condition:
@@ -390,6 +392,8 @@ class Condition(metaclass=abc.ABCMeta):
                 return OrCondition(self.children.extending(other.children))
             else:
                 return OrCondition(self.children.appending(other))
+        elif isinstance(other, OrCondition):
+            return OrCondition(other.children.prepending(self))
         return OrCondition(MinLen2AppendOnlyList.create(self, other))
 
     def __invert__(self) -> Condition:

--- a/src/aiodynamo/utils.py
+++ b/src/aiodynamo/utils.py
@@ -5,7 +5,6 @@ import datetime
 import decimal
 import logging
 from collections import abc as collections_abc
-from dataclasses import dataclass
 from functools import reduce
 from typing import (
     TYPE_CHECKING,
@@ -13,9 +12,6 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
-    Generator,
-    Generic,
-    Iterable,
     List,
     Mapping,
     Set,
@@ -201,28 +197,3 @@ def deparametetrize(
     for key, value in params.names.items():
         expression = expression.replace(key, value)
     return expression
-
-
-@dataclass(frozen=True)
-class MinLen2AppendOnlyList(Generic[T]):
-    first: T
-    second: T
-    rest: tuple[T, ...]
-
-    @classmethod
-    def create(cls, first: T, second: T, *rest: T) -> MinLen2AppendOnlyList[T]:
-        return cls(first, second, rest)
-
-    def prepending(self, value: T) -> MinLen2AppendOnlyList[T]:
-        return MinLen2AppendOnlyList(value, self.first, (self.second, *self.rest))
-
-    def appending(self, value: T) -> MinLen2AppendOnlyList[T]:
-        return MinLen2AppendOnlyList(self.first, self.second, (*self.rest, value))
-
-    def extending(self, values: Iterable[T]) -> MinLen2AppendOnlyList[T]:
-        return MinLen2AppendOnlyList(self.first, self.second, (*self.rest, *values))
-
-    def __iter__(self) -> Generator[T, None, None]:
-        yield self.first
-        yield self.second
-        yield from self.rest

--- a/src/aiodynamo/utils.py
+++ b/src/aiodynamo/utils.py
@@ -213,31 +213,16 @@ class MinLen2AppendOnlyList(Generic[T]):
     def create(cls, first: T, second: T, *rest: T) -> MinLen2AppendOnlyList[T]:
         return cls(first, second, rest)
 
+    def prepending(self, value: T) -> MinLen2AppendOnlyList[T]:
+        return MinLen2AppendOnlyList(value, self.first, (self.second, *self.rest))
+
     def appending(self, value: T) -> MinLen2AppendOnlyList[T]:
         return MinLen2AppendOnlyList(self.first, self.second, (*self.rest, value))
 
     def extending(self, values: Iterable[T]) -> MinLen2AppendOnlyList[T]:
         return MinLen2AppendOnlyList(self.first, self.second, (*self.rest, *values))
 
-    def __contains__(self, item: Any) -> bool:
-        return item == self.first or item == self.second or item in self.rest
-
-    def __getitem__(self, index: int) -> T:
-        if index == 0:
-            return self.first
-        elif index == 1:
-            return self.second
-        return self.rest[index - 2]
-
-    def __len__(self) -> int:
-        return len(self.rest) + 2
-
     def __iter__(self) -> Generator[T, None, None]:
         yield self.first
         yield self.second
         yield from self.rest
-
-    def __reversed__(self) -> Generator[T, None, None]:
-        yield from reversed(self.rest)
-        yield self.second
-        yield self.first

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -11,9 +11,9 @@ from aiodynamo.expressions import (
     OrCondition,
     Parameters,
     ProjectionExpression,
+    SubConditions,
     UpdateExpression,
 )
-from aiodynamo.utils import MinLen2AppendOnlyList
 
 
 @pytest.mark.parametrize(
@@ -149,7 +149,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
         (
             F("a").equals("a") & F("b").equals("b"),
             AndCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"), Comparison(F("b"), "=", "b")
                 )
             ),
@@ -157,7 +157,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
         (
             (F("a").equals("a") & F("b").equals("b")) & F("c").equals("c"),
             AndCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"),
                     Comparison(F("b"), "=", "b"),
                     Comparison(F("c"), "=", "c"),
@@ -167,7 +167,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
         (
             F("a").equals("a") & (F("b").equals("b") & F("c").equals("c")),
             AndCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"),
                     Comparison(F("b"), "=", "b"),
                     Comparison(F("c"), "=", "c"),
@@ -178,7 +178,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
             (F("a").equals("a") & F("b").equals("b"))
             & (F("c").equals("c") & F("d").equals("d")),
             AndCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"),
                     Comparison(F("b"), "=", "b"),
                     Comparison(F("c"), "=", "c"),
@@ -189,7 +189,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
         (
             F("a").equals("a") | F("b").equals("b"),
             OrCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"), Comparison(F("b"), "=", "b")
                 )
             ),
@@ -197,7 +197,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
         (
             (F("a").equals("a") | F("b").equals("b")) | F("c").equals("c"),
             OrCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"),
                     Comparison(F("b"), "=", "b"),
                     Comparison(F("c"), "=", "c"),
@@ -207,7 +207,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
         (
             F("a").equals("a") | (F("b").equals("b") | F("c").equals("c")),
             OrCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"),
                     Comparison(F("b"), "=", "b"),
                     Comparison(F("c"), "=", "c"),
@@ -218,7 +218,7 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
             (F("a").equals("a") | F("b").equals("b"))
             | (F("c").equals("c") | F("d").equals("d")),
             OrCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     Comparison(F("a"), "=", "a"),
                     Comparison(F("b"), "=", "b"),
                     Comparison(F("c"), "=", "c"),
@@ -230,14 +230,14 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
             (F("a").equals("a") | F("b").equals("b"))
             & (F("c").equals("c") | F("d").equals("d")),
             AndCondition(
-                MinLen2AppendOnlyList.create(
+                SubConditions.create(
                     OrCondition(
-                        MinLen2AppendOnlyList.create(
+                        SubConditions.create(
                             Comparison(F("a"), "=", "a"), Comparison(F("b"), "=", "b")
                         )
                     ),
                     OrCondition(
-                        MinLen2AppendOnlyList.create(
+                        SubConditions.create(
                             Comparison(F("c"), "=", "c"), Comparison(F("d"), "=", "d")
                         )
                     ),

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -165,6 +165,16 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
             ),
         ),
         (
+            F("a").equals("a") & (F("b").equals("b") & F("c").equals("c")),
+            AndCondition(
+                MinLen2AppendOnlyList.create(
+                    Comparison(F("a"), "=", "a"),
+                    Comparison(F("b"), "=", "b"),
+                    Comparison(F("c"), "=", "c"),
+                )
+            ),
+        ),
+        (
             (F("a").equals("a") & F("b").equals("b"))
             & (F("c").equals("c") & F("d").equals("d")),
             AndCondition(
@@ -186,6 +196,16 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
         ),
         (
             (F("a").equals("a") | F("b").equals("b")) | F("c").equals("c"),
+            OrCondition(
+                MinLen2AppendOnlyList.create(
+                    Comparison(F("a"), "=", "a"),
+                    Comparison(F("b"), "=", "b"),
+                    Comparison(F("c"), "=", "c"),
+                )
+            ),
+        ),
+        (
+            F("a").equals("a") | (F("b").equals("b") | F("c").equals("c")),
             OrCondition(
                 MinLen2AppendOnlyList.create(
                     Comparison(F("a"), "=", "a"),


### PR DESCRIPTION
Previously, AND and OR conditions with more than two elements would lead to nested ANDs and ORs, making the resulting expression much more complicated and harder to read/understand. This change flattens AndCondition and OrCondition objects when they're combined.

Context: had to debug some complicated conditions (~10 AND's) and the extreme nesting makes it super hard to debug/read them.

~Not a _huge_ fan of the name `MinLen2AppendOnlyList` so if someone has a better suggestion I'd love to hear it.~