### PR TITLE
Fix attribute type filter

### DIFF
--- a/src/aiodynamo/expressions.py
+++ b/src/aiodynamo/expressions.py
@@ -446,7 +446,7 @@ class AttributeTypeCondition(Condition):
     attribute_type: AttributeType
 
     def encode(self, params: Parameters) -> str:
-        return f"attribute_type({params.encode_path(self.field.path)}, {self.attribute_type.value})"
+        return f"attribute_type({params.encode_path(self.field.path)}, {params.encode_value(self.attribute_type.value)})"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Turns out the attribute type filter simply doesn't work at the moment 😅. The [documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Syntax) is quite clear on the subject that the attribute type tag needs to be parametrized.