### PR TITLE
add httpx and aiohttp as dev dependencies

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,7 +54,7 @@ jobs:
           path: poetry.lock
           key: ${{ github.sha }}-${{ matrix.python-version }}
       - run: curl -sSL https://install.python-poetry.org | python3 -
-      - run: poetry install --extras aiohttp --extras httpx
+      - run: poetry install
       - run: poetry run pytest --verbose
 
   mypy:
@@ -74,7 +74,7 @@ jobs:
           path: poetry.lock
           key: ${{ github.sha }}-${{ matrix.python-version }}
       - run: curl -sSL https://install.python-poetry.org | python3 -
-      - run: poetry install --extras aiohttp --extras httpx
+      - run: poetry install
       - run: poetry run mypy
 
   isort:
@@ -91,7 +91,7 @@ jobs:
           path: poetry.lock
           key: ${{ github.sha }}-3.12
       - run: curl -sSL https://install.python-poetry.org | python3 -
-      - run: poetry install --extras aiohttp --extras httpx
+      - run: poetry install
       - run: poetry run isort --check --diff src tests
 
   black:
@@ -108,7 +108,7 @@ jobs:
           path: poetry.lock
           key: ${{ github.sha }}-3.12
       - run: curl -sSL https://install.python-poetry.org | python3 -
-      - run: poetry install --extras aiohttp --extras httpx
+      - run: poetry install
       - run: poetry run black --check src/ tests/
 
   ruff:
@@ -125,5 +125,5 @@ jobs:
           path: poetry.lock
           key: ${{ github.sha }}-3.12
       - run: curl -sSL https://install.python-poetry.org | python3 -
-      - run: poetry install --extras aiohttp --extras httpx
+      - run: poetry install
       - run: poetry run ruff check src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ types-freezegun = "^1.1.6"
 urllib3 = "< 1.27"
 furo = "^2023.9.10"
 ruff = "^0.0.292"
+httpx = "^0.27.0"
+aiohttp = "^3.9.5"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ types-freezegun = "^1.1.6"
 urllib3 = "< 1.27"
 furo = "^2023.9.10"
 ruff = "^0.0.292"
-httpx = "^0.27.0"
-aiohttp = "^3.9.5"
+httpx = ">=0.15.0 <1.0.0"
+aiohttp = "^3.6.2"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
Because these two libs are required to run the test cases, making it (a tiny bit) easier to set up a new development environment.