### PR TITLE
add more error types

### DIFF
--- a/src/aiodynamo/errors.py
+++ b/src/aiodynamo/errors.py
@@ -186,6 +186,26 @@ class TransactionInProgress(AIODynamoError):
     pass
 
 
+class AccessDenied(AIODynamoError):
+    pass
+
+
+class IncompleteSignature(AIODynamoError):
+    pass
+
+
+class MissingAuthenticationToken(AIODynamoError):
+    pass
+
+
+class UnrecognizedClient(AIODynamoError):
+    pass
+
+
+class SerializationException(AIODynamoError):
+    pass
+
+
 ERRORS = {
     "ResourceNotFoundException": TableNotFound,
     "UnknownOperationException": UnknownOperation,
@@ -214,6 +234,11 @@ ERRORS = {
     "ResourceInUseException": ResourceInUse,
     "IdempotentParameterMismatchException": IdempotentParameterMismatch,
     "TransactionInProgressException": TransactionInProgress,
+    "AccessDeniedException": AccessDenied,
+    "IncompleteSignatureException": IncompleteSignature,
+    "MissingAuthenticationTokenException": MissingAuthenticationToken,
+    "UnrecognizedClientException": UnrecognizedClient,
+    "SerializationException": SerializationException,
 }
 
 


### PR DESCRIPTION
Add more pre-defined error types from the [official document](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html).  
  
Also, I added a `SerializationException`, which is not mentioned in the document but is found in dynalite. Someone on Stack Overflow also encountered this error when using DynamoDB, so I assume it is being used by DynamoDB as well.  
  
Related to #70