### PR TITLE
Support multi-attribute GSI partition and sort keys

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,8 +34,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         implementation: [
           {flavor: "dynalite", name: "dynalite"},
-          {flavor: "other", name: "dynamodb-local"},
-          {flavor: "other", name: "localstack"},
+          {flavor: "dynamodb-local", name: "dynamodb-local"},
+          {flavor: "localstack", name: "localstack"},
           {flavor: "scylla", name: "scylla"}
         ]
     runs-on: "ubuntu-latest"

--- a/src/aiodynamo/expressions.py
+++ b/src/aiodynamo/expressions.py
@@ -241,6 +241,9 @@ class KeyCondition(metaclass=abc.ABCMeta):
     def encode(self, params: Parameters) -> str:
         pass
 
+    def __and__(self, other: Condition) -> KeyCondition:
+        raise NotImplementedError
+
 
 @dataclass(frozen=True)
 class HashKey(KeyCondition):
@@ -375,6 +378,9 @@ class HashAndRangeKeyCondition(KeyCondition):
 
     def encode(self, params: Parameters) -> str:
         return f"{self.hash_key.encode(params)} AND {self.range_key_condition.encode(params)}"
+
+    def __and__(self, other: Condition) -> KeyCondition:
+        return HashAndRangeKeyCondition(self.hash_key, self.range_key_condition & other)
 
 
 class Condition(metaclass=abc.ABCMeta):
@@ -700,3 +706,57 @@ class SubConditions:
         yield self.first
         yield self.second
         yield from self.rest
+
+
+# Multi-attribute key support for GSI queries
+
+
+@dataclass(frozen=True, init=False)
+class MultiHashKey(KeyCondition):
+    """Multi-attribute partition key condition for GSI queries.
+
+    DynamoDB GSIs support up to 4 partition key attributes. All partition key
+    attributes must be specified with equality conditions.
+
+    Usage:
+        MultiHashKey(("pk1", value1), ("pk2", value2))
+
+    For sort key conditions, use the existing RangeKey class:
+        MultiHashKey(("pk1", v1), ("pk2", v2)) & RangeKey("sk").begins_with("x")
+
+    For multiple sort key conditions:
+        MultiHashKey(("pk1", v1), ("pk2", v2)) & RangeKey("sk1").equals(v1) & RangeKey("sk2").gt(0)
+    """
+
+    keys: Tuple[Tuple[str, Any], ...]
+
+    def __init__(self, *keys: Tuple[str, Any]) -> None:
+        if not (1 <= len(keys) <= 4):
+            raise ValueError("MultiHashKey requires 1-4 key attribute pairs")
+        object.__setattr__(self, "keys", keys)
+
+    def encode(self, params: Parameters) -> str:
+        parts = [
+            f"{params.encode_path(KeyPath(name))} = {params.encode_value(value)}"
+            for name, value in self.keys
+        ]
+        return " AND ".join(parts)
+
+    def __and__(self, other: Condition) -> KeyCondition:
+        return MultiHashAndRangeKeyCondition(self, other)
+
+
+@dataclass(frozen=True)
+class MultiHashAndRangeKeyCondition(KeyCondition):
+    """Multi-attribute partition key combined with sort key condition(s)."""
+
+    hash_key: MultiHashKey
+    range_key_condition: Condition
+
+    def encode(self, params: Parameters) -> str:
+        return f"{self.hash_key.encode(params)} AND {self.range_key_condition.encode(params)}"
+
+    def __and__(self, other: Condition) -> KeyCondition:
+        return MultiHashAndRangeKeyCondition(
+            self.hash_key, self.range_key_condition & other
+        )

--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -16,6 +16,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Tuple,
     Union,
     cast,
 )
@@ -90,23 +91,76 @@ class KeySpec:
 
 @dataclass(frozen=True)
 class KeySchema:
-    hash_key: KeySpec
-    range_key: Optional[KeySpec] = None
+    """Key schema supporting single or multi-attribute partition and sort keys.
+
+    For backward compatibility, single KeySpec values are accepted. For multi-attribute
+    keys (GSIs only), pass a tuple of KeySpec values.
+
+    DynamoDB supports up to 4 attributes each for partition (HASH) and sort (RANGE) keys.
+    """
+
+    hash_key: Union[KeySpec, Tuple[KeySpec, ...]]
+    range_key: Union[KeySpec, Tuple[KeySpec, ...], None] = None
+
+    def __post_init__(self) -> None:
+        hash_keys = self._normalize(self.hash_key)
+        if not (1 <= len(hash_keys) <= 4):
+            raise ValueError("hash_key must have 1-4 attributes")
+        if self.range_key:
+            range_keys = self._normalize(self.range_key)
+            if len(range_keys) > 4:
+                raise ValueError("range_key must have 0-4 attributes")
+
+    @staticmethod
+    def _normalize(key: Union[KeySpec, Tuple[KeySpec, ...]]) -> Tuple[KeySpec, ...]:
+        return key if isinstance(key, tuple) else (key,)
 
     def __iter__(self) -> Iterator[KeySpec]:
-        yield self.hash_key
-
+        yield from self._normalize(self.hash_key)
         if self.range_key:
-            yield self.range_key
+            yield from self._normalize(self.range_key)
 
     def to_attributes(self) -> Dict[str, str]:
         return {key.name: key.type.value for key in self}
 
     def encode(self) -> List[EncodedKeySchema]:
-        return [
-            {"AttributeName": key.name, "KeyType": key_type}
-            for key, key_type in zip(self, ["HASH", "RANGE"])
+        hash_keys = self._normalize(self.hash_key)
+        result: List[EncodedKeySchema] = [
+            {"AttributeName": k.name, "KeyType": "HASH"} for k in hash_keys
         ]
+        if self.range_key:
+            range_keys = self._normalize(self.range_key)
+            result.extend(
+                {"AttributeName": k.name, "KeyType": "RANGE"} for k in range_keys
+            )
+        return result
+
+    @classmethod
+    def from_response(
+        cls,
+        key_schema_list: List[Dict[str, str]],
+        attributes: Dict[str, KeyType],
+    ) -> "KeySchema":
+        """Parse KeySchema from DynamoDB response, handling multi-attribute keys."""
+        hash_keys: List[KeySpec] = []
+        range_keys: List[KeySpec] = []
+
+        for key in key_schema_list:
+            name = key["AttributeName"]
+            spec = KeySpec(name=name, type=attributes[name])
+            if key["KeyType"] == "HASH":
+                hash_keys.append(spec)
+            else:
+                range_keys.append(spec)
+
+        return cls(
+            hash_key=tuple(hash_keys) if len(hash_keys) > 1 else hash_keys[0],
+            range_key=(
+                (tuple(range_keys) if len(range_keys) > 1 else range_keys[0])
+                if range_keys
+                else None
+            ),
+        )
 
 
 class ProjectionType(Enum):
@@ -225,14 +279,7 @@ class TableDescription:
             creation_time = None
         key_schema: Optional[KeySchema]
         if attributes and "KeySchema" in description:
-            key_schema = KeySchema(
-                *[
-                    KeySpec(
-                        name=key["AttributeName"], type=attributes[key["AttributeName"]]
-                    )
-                    for key in description["KeySchema"]
-                ]
-            )
+            key_schema = KeySchema.from_response(description["KeySchema"], attributes)
         else:
             key_schema = None
         throughput: Optional[ThroughputType]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,8 @@ class Flavor(Enum):
     real = "real"
     scylla = "scylla"
     dynalite = "dynalite"
+    dynamodb_local = "dynamodb-local"
+    localstack = "localstack"
     other = "other"
 
 
@@ -103,10 +105,6 @@ def flavor(dynamodb_implementation: Implementation) -> Flavor:
 def real_dynamo(flavor: Flavor) -> bool:
     return flavor is Flavor.real
 
-
-@pytest.fixture(scope="session")
-def implementation_name(dynamodb_implementation: Implementation) -> str:
-    return dynamodb_implementation.name
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -106,7 +106,6 @@ def real_dynamo(flavor: Flavor) -> bool:
     return flavor is Flavor.real
 
 
-
 @pytest.fixture(scope="session")
 def scylla(flavor: Flavor) -> bool:
     return flavor is Flavor.scylla

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,6 +105,11 @@ def real_dynamo(flavor: Flavor) -> bool:
 
 
 @pytest.fixture(scope="session")
+def implementation_name(dynamodb_implementation: Implementation) -> str:
+    return dynamodb_implementation.name
+
+
+@pytest.fixture(scope="session")
 def scylla(flavor: Flavor) -> bool:
     return flavor is Flavor.scylla
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -3,7 +3,7 @@ import contextlib
 import secrets
 import typing
 from operator import itemgetter
-from typing import Any, List, Type
+from typing import Any, AsyncGenerator, List, Type
 
 import pytest
 from yarl import URL
@@ -21,7 +21,7 @@ from aiodynamo.errors import (
     UnknownOperation,
     ValidationException,
 )
-from aiodynamo.expressions import Condition, F, HashKey, RangeKey
+from aiodynamo.expressions import Condition, F, HashKey, MultiHashKey, RangeKey
 from aiodynamo.http.types import HttpImplementation
 from aiodynamo.models import (
     BatchGetRequest,
@@ -893,3 +893,189 @@ async def test_attribute_type_filter(client: Client, table: TableName) -> None:
         )
     }
     assert items == {"2"}
+
+
+# Multi-attribute GSI key tests
+
+MultiAttrGsiTable = typing.Tuple[TableName, str]
+
+
+@pytest.fixture
+async def multi_attr_gsi_table(
+    client: Client,
+    table_name_prefix: str,
+    wait_config: RetryConfig,
+    implementation_name: str,
+) -> AsyncGenerator[MultiAttrGsiTable, None]:
+    if implementation_name not in ("dynamodb-local", "Real DynamoDB"):
+        pytest.skip("Multi-attribute GSI keys not supported by this backend")
+
+    name = table_name_prefix + secrets.token_hex(4)
+    gsi_name = "tenant-region-index"
+    await client.create_table(
+        name,
+        Throughput(5, 5),
+        KeySchema(KeySpec("h", KeyType.string), KeySpec("r", KeyType.string)),
+        gsis=[
+            GlobalSecondaryIndex(
+                name=gsi_name,
+                schema=KeySchema(
+                    hash_key=(
+                        KeySpec("tenant", KeyType.string),
+                        KeySpec("region", KeyType.string),
+                    ),
+                    range_key=(
+                        KeySpec("date", KeyType.string),
+                        KeySpec("seq", KeyType.number),
+                    ),
+                ),
+                projection=Projection(ProjectionType.all),
+                throughput=Throughput(5, 5),
+            )
+        ],
+        wait_for_active=wait_config,
+    )
+
+    for item in [
+        {
+            "h": "1",
+            "r": "a",
+            "tenant": "acme",
+            "region": "us-east",
+            "date": "2025-01-01",
+            "seq": 1,
+        },
+        {
+            "h": "2",
+            "r": "b",
+            "tenant": "acme",
+            "region": "us-east",
+            "date": "2025-01-01",
+            "seq": 2,
+        },
+        {
+            "h": "3",
+            "r": "c",
+            "tenant": "acme",
+            "region": "us-east",
+            "date": "2025-01-02",
+            "seq": 1,
+        },
+        {
+            "h": "4",
+            "r": "d",
+            "tenant": "acme",
+            "region": "eu-west",
+            "date": "2025-01-01",
+            "seq": 1,
+        },
+        {
+            "h": "5",
+            "r": "e",
+            "tenant": "other",
+            "region": "us-east",
+            "date": "2025-01-01",
+            "seq": 1,
+        },
+    ]:
+        await client.put_item(name, item)
+
+    try:
+        yield name, gsi_name
+    finally:
+        await client.delete_table(name)
+
+
+async def test_multi_attr_gsi_query_partition_only(
+    client: Client, multi_attr_gsi_table: MultiAttrGsiTable
+) -> None:
+    table, gsi_name = multi_attr_gsi_table
+    results = [
+        item
+        async for item in client.query(
+            table,
+            MultiHashKey(("tenant", "acme"), ("region", "us-east")),
+            index=gsi_name,
+        )
+    ]
+    assert len(results) == 3
+    assert all(
+        item["tenant"] == "acme" and item["region"] == "us-east" for item in results
+    )
+
+
+async def test_multi_attr_gsi_query_with_first_sort_key_equals(
+    client: Client, multi_attr_gsi_table: MultiAttrGsiTable
+) -> None:
+    table, gsi_name = multi_attr_gsi_table
+    results = [
+        item
+        async for item in client.query(
+            table,
+            MultiHashKey(("tenant", "acme"), ("region", "us-east"))
+            & RangeKey("date").equals("2025-01-01"),
+            index=gsi_name,
+        )
+    ]
+    assert len(results) == 2
+    assert all(item["date"] == "2025-01-01" for item in results)
+
+
+async def test_multi_attr_gsi_query_with_first_sort_key_between(
+    client: Client, multi_attr_gsi_table: MultiAttrGsiTable
+) -> None:
+    table, gsi_name = multi_attr_gsi_table
+    results = [
+        item
+        async for item in client.query(
+            table,
+            MultiHashKey(("tenant", "acme"), ("region", "us-east"))
+            & RangeKey("date").between("2025-01-01", "2025-01-02"),
+            index=gsi_name,
+        )
+    ]
+    assert len(results) == 3
+
+
+async def test_multi_attr_gsi_query_with_sort_key_inequality(
+    client: Client, multi_attr_gsi_table: MultiAttrGsiTable
+) -> None:
+    table, gsi_name = multi_attr_gsi_table
+    results = [
+        item
+        async for item in client.query(
+            table,
+            MultiHashKey(("tenant", "acme"), ("region", "us-east"))
+            & RangeKey("date").equals("2025-01-01")
+            & RangeKey("seq").gte(2),
+            index=gsi_name,
+        )
+    ]
+    assert len(results) == 1
+    assert results[0]["seq"] == 2
+    assert results[0]["h"] == "2"
+
+
+async def test_multi_attr_gsi_query_with_sort_key_between(
+    client: Client, multi_attr_gsi_table: MultiAttrGsiTable
+) -> None:
+    table, gsi_name = multi_attr_gsi_table
+    results = [
+        item
+        async for item in client.query(
+            table,
+            MultiHashKey(("tenant", "acme"), ("region", "us-east"))
+            & RangeKey("date").equals("2025-01-01")
+            & RangeKey("seq").between(1, 2),
+            index=gsi_name,
+        )
+    ]
+    assert len(results) == 2
+
+
+async def test_multi_attr_gsi_describe_table(
+    client: Client, multi_attr_gsi_table: MultiAttrGsiTable
+) -> None:
+    table, _ = multi_attr_gsi_table
+    description = await client.describe_table(table)
+    assert description.key_schema is not None

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -42,7 +42,7 @@ from aiodynamo.models import (
 )
 from aiodynamo.operations import ConditionCheck, Delete, Get, Put, Update
 from aiodynamo.types import AttributeType, TableName
-from tests.integration.conftest import TableFactory
+from tests.integration.conftest import Flavor, TableFactory
 
 
 async def test_create_table_with_indices(
@@ -905,9 +905,9 @@ async def multi_attr_gsi_table(
     client: Client,
     table_name_prefix: str,
     wait_config: RetryConfig,
-    implementation_name: str,
+    flavor: Flavor,
 ) -> AsyncGenerator[MultiAttrGsiTable, None]:
-    if implementation_name not in ("dynamodb-local", "Real DynamoDB"):
+    if flavor not in (Flavor.dynamodb_local, Flavor.real):
         pytest.skip("Multi-attribute GSI keys not supported by this backend")
 
     name = table_name_prefix + secrets.token_hex(4)

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -8,9 +8,11 @@ from aiodynamo.expressions import (
     Condition,
     F,
     HashKey,
+    MultiHashKey,
     OrCondition,
     Parameters,
     ProjectionExpression,
+    RangeKey,
     SubConditions,
     UpdateExpression,
 )
@@ -248,3 +250,131 @@ def test_update_expression_debug(expr: UpdateExpression, expected: str) -> None:
 )
 def test_condition_flattening(expr: Condition, expected: Condition) -> None:
     assert expr == expected
+
+
+# Multi-attribute key tests
+
+
+@pytest.mark.parametrize(
+    "multi_hash_key,encoded,ean,eav",
+    [
+        (
+            MultiHashKey(("pk1", "v1")),
+            "#n0 = :v0",
+            {"#n0": "pk1"},
+            {":v0": {"S": "v1"}},
+        ),
+        (
+            MultiHashKey(("pk1", "v1"), ("pk2", "v2")),
+            "#n0 = :v0 AND #n1 = :v1",
+            {"#n0": "pk1", "#n1": "pk2"},
+            {":v0": {"S": "v1"}, ":v1": {"S": "v2"}},
+        ),
+        (
+            MultiHashKey(("tenant", "acme"), ("region", "us-east"), ("env", "prod")),
+            "#n0 = :v0 AND #n1 = :v1 AND #n2 = :v2",
+            {"#n0": "tenant", "#n1": "region", "#n2": "env"},
+            {":v0": {"S": "acme"}, ":v1": {"S": "us-east"}, ":v2": {"S": "prod"}},
+        ),
+    ],
+)
+def test_multi_hash_key_encoding(
+    multi_hash_key: MultiHashKey,
+    encoded: str,
+    ean: Dict[str, str],
+    eav: Dict[str, Dict[str, str]],
+) -> None:
+    params = Parameters()
+    assert multi_hash_key.encode(params) == encoded
+    payload = params.to_request_payload()
+    assert payload["ExpressionAttributeNames"] == ean
+    assert payload["ExpressionAttributeValues"] == eav
+
+
+def test_multi_hash_and_range_key_condition() -> None:
+    """Test combining multi-attribute hash key with range key condition."""
+    condition = MultiHashKey(("pk1", "v1"), ("pk2", "v2")) & RangeKey("sk1").equals("a")
+    params = Parameters()
+    encoded = condition.encode(params)
+    assert encoded == "#n0 = :v0 AND #n1 = :v1 AND #n2 = :v2"
+    payload = params.to_request_payload()
+    assert payload["ExpressionAttributeNames"] == {
+        "#n0": "pk1",
+        "#n1": "pk2",
+        "#n2": "sk1",
+    }
+    assert payload["ExpressionAttributeValues"] == {
+        ":v0": {"S": "v1"},
+        ":v1": {"S": "v2"},
+        ":v2": {"S": "a"},
+    }
+
+
+def test_multi_hash_with_chained_range_conditions() -> None:
+    """Test multi-attribute hash key with multiple range key conditions."""
+    condition = MultiHashKey(("pk1", "v1"), ("pk2", "v2")) & (
+        RangeKey("sk1").equals("a") & RangeKey("sk2").gt(0)
+    )
+    params = Parameters()
+    encoded = condition.encode(params)
+    assert encoded == "#n0 = :v0 AND #n1 = :v1 AND (#n2 = :v2 AND #n3 > :v3)"
+
+
+def test_hash_key_chained_range_without_parens() -> None:
+    """HashKey & RangeKey(...) & RangeKey(...) should work without parentheses."""
+    condition = HashKey("h", "v") & RangeKey("r1").equals("a") & RangeKey("r2").gt(0)
+    params = Parameters()
+    encoded = condition.encode(params)
+    assert encoded == "#n0 = :v0 AND (#n1 = :v1 AND #n2 > :v2)"
+    payload = params.to_request_payload()
+    assert payload["ExpressionAttributeNames"] == {
+        "#n0": "h",
+        "#n1": "r1",
+        "#n2": "r2",
+    }
+    assert payload["ExpressionAttributeValues"] == {
+        ":v0": {"S": "v"},
+        ":v1": {"S": "a"},
+        ":v2": {"N": "0"},
+    }
+
+
+def test_multi_hash_key_chained_range_without_parens() -> None:
+    """MultiHashKey & RangeKey(...) & RangeKey(...) should work without parentheses."""
+    condition = (
+        MultiHashKey(("pk1", "v1"), ("pk2", "v2"))
+        & RangeKey("sk1").equals("a")
+        & RangeKey("sk2").gt(0)
+    )
+    params = Parameters()
+    encoded = condition.encode(params)
+    assert encoded == "#n0 = :v0 AND #n1 = :v1 AND (#n2 = :v2 AND #n3 > :v3)"
+    payload = params.to_request_payload()
+    assert payload["ExpressionAttributeNames"] == {
+        "#n0": "pk1",
+        "#n1": "pk2",
+        "#n2": "sk1",
+        "#n3": "sk2",
+    }
+    assert payload["ExpressionAttributeValues"] == {
+        ":v0": {"S": "v1"},
+        ":v1": {"S": "v2"},
+        ":v2": {"S": "a"},
+        ":v3": {"N": "0"},
+    }
+
+
+def test_multi_hash_key_empty_raises() -> None:
+    """MultiHashKey with no keys should raise ValueError."""
+    with pytest.raises(
+        ValueError, match="MultiHashKey requires 1-4 key attribute pairs"
+    ):
+        MultiHashKey()
+
+
+def test_multi_hash_key_too_many_raises() -> None:
+    """MultiHashKey with more than 4 keys should raise ValueError."""
+    with pytest.raises(
+        ValueError, match="MultiHashKey requires 1-4 key attribute pairs"
+    ):
+        MultiHashKey(("a", 1), ("b", 2), ("c", 3), ("d", 4), ("e", 5))

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,136 @@
+import pytest
+
+from aiodynamo.models import KeySchema, KeySpec, KeyType
+
+
+class TestKeySchema:
+    """Tests for KeySchema multi-attribute key support."""
+
+    def test_single_hash_key(self) -> None:
+        """Test backward compatible single hash key."""
+        schema = KeySchema(KeySpec("h", KeyType.string))
+        assert schema.encode() == [{"AttributeName": "h", "KeyType": "HASH"}]
+
+    def test_single_hash_and_range_key(self) -> None:
+        """Test backward compatible single hash and range key."""
+        schema = KeySchema(KeySpec("h", KeyType.string), KeySpec("r", KeyType.string))
+        assert schema.encode() == [
+            {"AttributeName": "h", "KeyType": "HASH"},
+            {"AttributeName": "r", "KeyType": "RANGE"},
+        ]
+
+    def test_multi_hash_keys(self) -> None:
+        """Test multi-attribute partition key."""
+        schema = KeySchema(
+            hash_key=(KeySpec("pk1", KeyType.string), KeySpec("pk2", KeyType.number))
+        )
+        assert schema.encode() == [
+            {"AttributeName": "pk1", "KeyType": "HASH"},
+            {"AttributeName": "pk2", "KeyType": "HASH"},
+        ]
+
+    def test_multi_range_keys(self) -> None:
+        """Test multi-attribute sort key."""
+        schema = KeySchema(
+            hash_key=KeySpec("h", KeyType.string),
+            range_key=(KeySpec("sk1", KeyType.string), KeySpec("sk2", KeyType.number)),
+        )
+        assert schema.encode() == [
+            {"AttributeName": "h", "KeyType": "HASH"},
+            {"AttributeName": "sk1", "KeyType": "RANGE"},
+            {"AttributeName": "sk2", "KeyType": "RANGE"},
+        ]
+
+    def test_multi_hash_and_range_keys(self) -> None:
+        """Test multi-attribute partition and sort keys."""
+        schema = KeySchema(
+            hash_key=(KeySpec("pk1", KeyType.string), KeySpec("pk2", KeyType.string)),
+            range_key=(KeySpec("sk1", KeyType.string), KeySpec("sk2", KeyType.number)),
+        )
+        assert schema.encode() == [
+            {"AttributeName": "pk1", "KeyType": "HASH"},
+            {"AttributeName": "pk2", "KeyType": "HASH"},
+            {"AttributeName": "sk1", "KeyType": "RANGE"},
+            {"AttributeName": "sk2", "KeyType": "RANGE"},
+        ]
+
+    def test_max_hash_keys(self) -> None:
+        """Test maximum 4 hash key attributes."""
+        schema = KeySchema(
+            hash_key=(
+                KeySpec("pk1", KeyType.string),
+                KeySpec("pk2", KeyType.string),
+                KeySpec("pk3", KeyType.string),
+                KeySpec("pk4", KeyType.string),
+            )
+        )
+        assert len([k for k in schema.encode() if k["KeyType"] == "HASH"]) == 4
+
+    def test_max_range_keys(self) -> None:
+        """Test maximum 4 range key attributes."""
+        schema = KeySchema(
+            hash_key=KeySpec("h", KeyType.string),
+            range_key=(
+                KeySpec("sk1", KeyType.string),
+                KeySpec("sk2", KeyType.string),
+                KeySpec("sk3", KeyType.string),
+                KeySpec("sk4", KeyType.string),
+            ),
+        )
+        assert len([k for k in schema.encode() if k["KeyType"] == "RANGE"]) == 4
+
+    def test_to_attributes(self) -> None:
+        """Test to_attributes returns all key attributes."""
+        schema = KeySchema(
+            hash_key=(KeySpec("pk1", KeyType.string), KeySpec("pk2", KeyType.number)),
+            range_key=(KeySpec("sk1", KeyType.binary),),
+        )
+        assert schema.to_attributes() == {"pk1": "S", "pk2": "N", "sk1": "B"}
+
+    def test_iter(self) -> None:
+        """Test iteration yields all key specs."""
+        schema = KeySchema(
+            hash_key=(KeySpec("pk1", KeyType.string), KeySpec("pk2", KeyType.number)),
+            range_key=(KeySpec("sk1", KeyType.string),),
+        )
+        keys = list(schema)
+        assert len(keys) == 3
+        assert keys[0].name == "pk1"
+        assert keys[1].name == "pk2"
+        assert keys[2].name == "sk1"
+
+
+class TestKeySchemaValidation:
+    """Tests for KeySchema validation."""
+
+    def test_empty_hash_keys_raises(self) -> None:
+        """Test that empty hash_keys tuple raises ValueError."""
+        with pytest.raises(ValueError, match="hash_key must have 1-4 attributes"):
+            KeySchema(hash_key=())
+
+    def test_too_many_hash_keys_raises(self) -> None:
+        """Test that more than 4 hash keys raises ValueError."""
+        with pytest.raises(ValueError, match="hash_key must have 1-4 attributes"):
+            KeySchema(
+                hash_key=(
+                    KeySpec("pk1", KeyType.string),
+                    KeySpec("pk2", KeyType.string),
+                    KeySpec("pk3", KeyType.string),
+                    KeySpec("pk4", KeyType.string),
+                    KeySpec("pk5", KeyType.string),
+                )
+            )
+
+    def test_too_many_range_keys_raises(self) -> None:
+        """Test that more than 4 range keys raises ValueError."""
+        with pytest.raises(ValueError, match="range_key must have 0-4 attributes"):
+            KeySchema(
+                hash_key=KeySpec("h", KeyType.string),
+                range_key=(
+                    KeySpec("sk1", KeyType.string),
+                    KeySpec("sk2", KeyType.string),
+                    KeySpec("sk3", KeyType.string),
+                    KeySpec("sk4", KeyType.string),
+                    KeySpec("sk5", KeyType.string),
+                ),
+            )


### PR DESCRIPTION
Closes #202

DynamoDB added support for multi-attribute composite keys on GSIs late last year. This PR adds support for that feature.

Docs: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.DesignPattern.MultiAttributeKeys.html

**KeySchema** now accepts tuples of `KeySpec` for `hash_key` and `range_key`, with validation enforcing DynamoDB's 1-4 attribute limit per key type. Single `KeySpec` values still work as before.

**MultiHashKey** is a new expression class for querying multi-attribute partition keys:

```python
# Table creation
gsi = GlobalSecondaryIndex(
    name="tenant-region-index",
    schema=KeySchema(
        hash_key=(KeySpec("tenant", KeyType.string), KeySpec("region", KeyType.string)),
        range_key=(KeySpec("date", KeyType.string), KeySpec("seq", KeyType.number)),
    ),
    projection=Projection(ProjectionType.all),
    throughput=None,
)

# Querying
async for item in client.query(
    "my-table",
    MultiHashKey(("tenant", "acme"), ("region", "us-east"))
    & RangeKey("date").equals("2025-01-01")
    & RangeKey("seq").gt(0),
    index="tenant-region-index",
):
    pass
```

Also fixes `HashAndRangeKeyCondition` missing `__and__`, which meant chaining multiple `RangeKey` conditions required explicit parentheses.