### PR TITLE
Add support for ReturnValuesOnConditionCheckFailure

### DIFF
--- a/.github/docker-compose/docker-compose.localstack.yml
+++ b/.github/docker-compose/docker-compose.localstack.yml
@@ -1,6 +1,0 @@
-version: "3.9"
-services:
-  dynamodb:
-    image: "localstack/localstack:0.14.2"
-    ports:
-      - "8000:4566"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,7 +35,6 @@ jobs:
         implementation: [
           {flavor: "dynalite", name: "dynalite"},
           {flavor: "other", name: "dynamodb-local"},
-          {flavor: "other", name: "localstack"},
           {flavor: "scylla", name: "scylla"}
         ]
     runs-on: "ubuntu-latest"

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -399,6 +399,10 @@ Models
     :members: none, all_old, updated_old, all_new, updated_new
     :undoc-members:
 
+.. autoclass:: aiodynamo.models.ReturnValuesOnConditionCheckFailure
+    :members: none, all_old
+    :undoc-members:
+
 .. autoclass:: aiodynamo.models.Projection
     :members: type, attrs
     :undoc-members:

--- a/src/aiodynamo/client.py
+++ b/src/aiodynamo/client.py
@@ -60,6 +60,7 @@ from .models import (
     RetryConfig,
     RetryTimeout,
     ReturnValues,
+    ReturnValuesOnConditionCheckFailure,
     Select,
     StreamSpecification,
     TableDescription,
@@ -143,10 +144,15 @@ class Table:
         key: Dict[str, Any],
         *,
         return_values: ReturnValues = ReturnValues.none,
+        return_values_on_condition_check_failure: ReturnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.none,
         condition: Optional[Condition] = None,
     ) -> Union[None, Item]:
         return await self.client.delete_item(
-            self.name, key, return_values=return_values, condition=condition
+            self.name,
+            key,
+            return_values=return_values,
+            condition=condition,
+            return_values_on_condition_check_failure=return_values_on_condition_check_failure,
         )
 
     async def get_item(
@@ -170,6 +176,7 @@ class Table:
         item: Dict[str, Any],
         *,
         return_values: ReturnValues = ReturnValues.none,
+        return_values_on_condition_check_failure: ReturnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.none,
         condition: Optional[Condition] = None,
     ) -> Union[None, Item]:
         """
@@ -177,7 +184,11 @@ class Table:
         This will overwrite all attributes in an item.
         """
         return await self.client.put_item(
-            self.name, item, return_values=return_values, condition=condition
+            self.name,
+            item,
+            return_values=return_values,
+            return_values_on_condition_check_failure=return_values_on_condition_check_failure,
+            condition=condition,
         )
 
     def query(
@@ -346,6 +357,7 @@ class Table:
         update_expression: UpdateExpression,
         *,
         return_values: ReturnValues = ReturnValues.none,
+        return_values_on_condition_check_failure: ReturnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.none,
         condition: Optional[Condition] = None,
     ) -> Union[Item, None]:
         """
@@ -357,6 +369,7 @@ class Table:
             key,
             update_expression,
             return_values=return_values,
+            return_values_on_condition_check_failure=return_values_on_condition_check_failure,
             condition=condition,
         )
 
@@ -513,6 +526,7 @@ class Client:
         key: Dict[str, Any],
         *,
         return_values: ReturnValues = ReturnValues.none,
+        return_values_on_condition_check_failure: ReturnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.none,
         condition: Optional[Condition] = None,
     ) -> Union[None, Item]:
         dynamo_key = py2dy(key)
@@ -523,6 +537,7 @@ class Client:
             "TableName": table,
             "Key": dynamo_key,
             "ReturnValues": return_values.value,
+            "ReturnValuesOnConditionCheckFailure": return_values_on_condition_check_failure.value,
         }
 
         if condition:
@@ -590,6 +605,7 @@ class Client:
         item: Dict[str, Any],
         *,
         return_values: ReturnValues = ReturnValues.none,
+        return_values_on_condition_check_failure: ReturnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.none,
         condition: Optional[Condition] = None,
     ) -> Union[None, Item]:
         dynamo_item = py2dy(item)
@@ -599,6 +615,7 @@ class Client:
             "TableName": table,
             "Item": dynamo_item,
             "ReturnValues": return_values.value,
+            "ReturnValuesOnConditionCheckFailure": return_values_on_condition_check_failure.value,
         }
         if condition:
             params = Parameters()
@@ -835,6 +852,7 @@ class Client:
         update_expression: UpdateExpression,
         *,
         return_values: ReturnValues = ReturnValues.none,
+        return_values_on_condition_check_failure: ReturnValuesOnConditionCheckFailure = ReturnValuesOnConditionCheckFailure.none,
         condition: Optional[Condition] = None,
     ) -> Union[Item, None]:
         params = Parameters()
@@ -848,6 +866,7 @@ class Client:
             "Key": py2dy(key),
             "UpdateExpression": expression,
             "ReturnValues": return_values.value,
+            "ReturnValuesOnConditionCheckFailure": return_values_on_condition_check_failure.value,
         }
         if condition:
             payload["ConditionExpression"] = condition.encode(params)
@@ -1013,7 +1032,11 @@ class Client:
                 if response.status == 200:
                     self.health_monitor.on_success()
                     return cast(Dict[str, Any], json.loads(response.body))
-                exception = exception_from_response(response.status, response.body)
+                exception = exception_from_response(
+                    response.status,
+                    response.body,
+                    self.numeric_type,
+                )
                 self.handle_exception(exception)
         except RetryTimeout:
             if exception is not None:

--- a/src/aiodynamo/errors.py
+++ b/src/aiodynamo/errors.py
@@ -2,6 +2,9 @@ import json
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from .types import NumericTypeConverter
+from .utils import dy2py
+
 
 @dataclass(frozen=True)
 class CancellationReason:
@@ -93,7 +96,10 @@ class BackupNotFound(AIODynamoError):
 
 
 class ConditionalCheckFailed(AIODynamoError):
-    pass
+    def __init__(self, body: Dict[str, Any], numeric_type: NumericTypeConverter):
+        item = body.get("Item")
+        self.item = dy2py(item, numeric_type) if item is not None else None
+        super().__init__(body)
 
 
 class TransactionConflict(AIODynamoError):
@@ -119,7 +125,7 @@ class PointInTimeRecoveryUnavailable(AIODynamoError):
 class TransactionCanceled(AIODynamoError):
     cancellation_reasons: List[Optional[CancellationReason]]
 
-    def __init__(self, body: Dict[str, Any]):
+    def __init__(self, body: Dict[str, Any], _numeric_type: NumericTypeConverter):
         self.body = body
         self.cancellation_reasons: List[Optional[CancellationReason]] = [
             CancellationReason(reason["Code"], reason["Message"])
@@ -242,14 +248,18 @@ ERRORS = {
 }
 
 
-def exception_from_response(status: int, body: bytes) -> Exception:
+def exception_from_response(
+    status: int,
+    body: bytes,
+    numeric_type: NumericTypeConverter,
+) -> Exception:
     if status == 500:
         return InternalDynamoError()
     elif status == 503:
         return ServiceUnavailable()
     try:
         data = json.loads(body)
-        error: Exception = ERRORS[data["__type"].split("#", 1)[-1]](data)
+        error: Exception = ERRORS[data["__type"].split("#", 1)[-1]](data, numeric_type)
         return error
     except Exception:
         return UnknownError(status, body)

--- a/src/aiodynamo/models.py
+++ b/src/aiodynamo/models.py
@@ -190,6 +190,11 @@ class ReturnValues(Enum):
     updated_new = "UPDATED_NEW"
 
 
+class ReturnValuesOnConditionCheckFailure(Enum):
+    none = "NONE"
+    all_old = "ALL_OLD"
+
+
 class TableStatus(Enum):
     creating = "CREATING"
     updating = "UPDATING"

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -36,6 +36,7 @@ from aiodynamo.models import (
     ProjectionType,
     RetryConfig,
     ReturnValues,
+    ReturnValuesOnConditionCheckFailure,
     TableStatus,
     Throughput,
     TimeToLiveStatus,
@@ -893,3 +894,97 @@ async def test_attribute_type_filter(client: Client, table: TableName) -> None:
         )
     }
     assert items == {"2"}
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ReturnValuesOnConditionCheckFailure.all_old,
+        ReturnValuesOnConditionCheckFailure.none,
+    ],
+)
+async def test_delete_item_with_return_value_on_condition_check_failure(
+    client: Client,
+    table: TableName,
+    value: ReturnValuesOnConditionCheckFailure,
+    dynalite: bool,
+) -> None:
+    if dynalite:
+        pytest.skip("feature not supported by dynalite")
+
+    item = {"h": "h", "r": "1", "d": "x"}
+    await client.put_item(table, item)
+    with pytest.raises(errors.ConditionalCheckFailed) as exc_info:
+        await client.delete_item(
+            table,
+            {"h": "h", "r": "1"},
+            return_values_on_condition_check_failure=value,
+            condition=F("d").does_not_exist(),
+        )
+    if value == ReturnValuesOnConditionCheckFailure.all_old:
+        assert exc_info.value.item == item
+    else:
+        assert exc_info.value.item is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ReturnValuesOnConditionCheckFailure.all_old,
+        ReturnValuesOnConditionCheckFailure.none,
+    ],
+)
+async def test_put_item_with_return_value_on_condition_check_failure(
+    client: Client,
+    table: TableName,
+    value: ReturnValuesOnConditionCheckFailure,
+    dynalite: bool,
+) -> None:
+    if dynalite:
+        pytest.skip("feature not supported by dynalite")
+
+    item = {"h": "h", "r": "1", "d": "x"}
+    await client.put_item(table, item)
+    with pytest.raises(errors.ConditionalCheckFailed) as exc_info:
+        await client.put_item(
+            table,
+            item,
+            return_values_on_condition_check_failure=value,
+            condition=F("d").does_not_exist(),
+        )
+    if value == ReturnValuesOnConditionCheckFailure.all_old:
+        assert exc_info.value.item == item
+    else:
+        assert exc_info.value.item is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ReturnValuesOnConditionCheckFailure.all_old,
+        ReturnValuesOnConditionCheckFailure.none,
+    ],
+)
+async def test_update_item_with_return_value_on_condition_check_failure(
+    client: Client,
+    table: TableName,
+    value: ReturnValuesOnConditionCheckFailure,
+    dynalite: bool,
+) -> None:
+    if dynalite:
+        pytest.skip("feature not supported by dynalite")
+
+    item = {"h": "h", "r": "1", "d": "x"}
+    await client.put_item(table, item)
+    with pytest.raises(errors.ConditionalCheckFailed) as exc_info:
+        await client.update_item(
+            table,
+            {"h": "h", "r": "1"},
+            update_expression=F("d").set("y"),
+            return_values_on_condition_check_failure=value,
+            condition=F("d").does_not_exist(),
+        )
+    if value == ReturnValuesOnConditionCheckFailure.all_old:
+        assert exc_info.value.item == item
+    else:
+        assert exc_info.value.item is None


### PR DESCRIPTION
Add support for the DeleteItem, PutItem and UpdateItem ReturnValuesOnConditionCheckFailure optional parameter. When set to "ALL_OLD", the ConditionalCheckFailed exception includes the item that failed the condition check.